### PR TITLE
Refactor: Split core logic into shared library and CLI tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SRC_FILE="src/main.cpp"
-
-          VERSION="$(grep -E '^[[:space:]]*#define[[:space:]]+ODIN4_VERSION[[:space:]]+"' "$SRC_FILE" \
+          SRC_FILE="include/odin4/odin4.h"
+          # Note: Version is now in odin4.cpp but we can also keep it in a central place.
+          # For now, let's extract it from src/odin4.cpp where it's defined.
+          VERSION="$(grep -E '^[[:space:]]*#define[[:space:]]+ODIN4_VERSION[[:space:]]+"' "src/odin4.cpp" \
             | sed -E 's/.*ODIN4_VERSION[[:space:]]+"([^"]+)".*/\1/' \
             | head -n 1)"
 
@@ -92,6 +93,7 @@ jobs:
           echo "ODIN4_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "ODIN4_SUFFIX=$SUFFIX" >> "$GITHUB_ENV"
           echo "ODIN4_OUTNAME=odin4_${{ matrix.arch }}_${VERSION}${SUFFIX}" >> "$GITHUB_ENV"
+          echo "LIB_OUTNAME=libodin4_${{ matrix.arch }}_${VERSION}${SUFFIX}.so" >> "$GITHUB_ENV"
 
       - name: Clean build dir
         shell: bash
@@ -118,10 +120,16 @@ jobs:
         run: |
           set -euo pipefail
           BIN="build/odin4"
+          LIB="build/libodin4.so"
           if [ ! -f "$BIN" ]; then
             echo "ERROR: build/odin4 not found." >&2
             exit 1
           fi
+          if [ ! -f "$LIB" ]; then
+            echo "ERROR: build/libodin4.so not found." >&2
+            exit 1
+          fi
+          # The CLI now depends on libodin4.so, but we want to ensure it doesn't depend on libcrypto++.so directly
           if ldd "$BIN" | grep -qiE 'libcrypto\+\+\.so'; then
             echo "ERROR: Binary still depends on libcrypto++.so." >&2
             exit 1
@@ -133,11 +141,13 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           cp build/odin4 "dist/${ODIN4_OUTNAME}"
+          cp build/libodin4.so "dist/${LIB_OUTNAME}"
           strip "dist/${ODIN4_OUTNAME}" || true
+          strip "dist/${LIB_OUTNAME}" || true
           ZIP_NAME="odin4-linux-${{ matrix.arch }}-${ODIN4_VERSION}${ODIN4_SUFFIX}.zip"
           (
             cd dist
-            zip "../${ZIP_NAME}" "${ODIN4_OUTNAME}"
+            zip "../${ZIP_NAME}" "${ODIN4_OUTNAME}" "${LIB_OUTNAME}"
           )
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,51 +70,71 @@ add_library(lz4_lib STATIC
 target_include_directories(lz4_lib PUBLIC lib/lz4)
 
 # =========================
-# Main executable (C++)
+# Shared Library (C++)
 # =========================
-add_executable(odin4
-    src/main.cpp
+add_library(odin4_lib SHARED
+    src/odin4.cpp
     src/core/logger.cpp
     src/usb/usb_device.cpp
     src/firmware/firmware_package.cpp
 )
-set_target_properties(odin4 PROPERTIES OUTPUT_NAME "odin4")
-
-# =========================
-# Compile options
-# =========================
-target_compile_options(odin4 PRIVATE
-    -Wall
-    -Wextra
-    -Wno-cast-function-type
+set_target_properties(odin4_lib PROPERTIES 
+    OUTPUT_NAME "odin4"
+    VERSION "5.1.0"
+    SOVERSION "5"
 )
 
-# =========================
-# Includes
-# =========================
-target_include_directories(odin4 PRIVATE
+target_include_directories(odin4_lib PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_include_directories(odin4_lib PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${LIBUSB_INCLUDE_DIRS}
 )
 
 if (CRYPTOPP_USE_STATIC)
-    target_include_directories(odin4 PRIVATE ${CRYPTOPP_INCLUDE_DIR})
+    target_include_directories(odin4_lib PRIVATE ${CRYPTOPP_INCLUDE_DIR})
 else()
-    target_include_directories(odin4 PRIVATE ${CRYPTOPP_INCLUDE_DIRS})
+    target_include_directories(odin4_lib PRIVATE ${CRYPTOPP_INCLUDE_DIRS})
 endif()
+
+target_link_libraries(odin4_lib PRIVATE
+    ${LIBUSB_LIBRARIES}
+    lz4_lib
+)
+
+if (CRYPTOPP_USE_STATIC)
+    target_link_libraries(odin4_lib PRIVATE ${CRYPTOPP_STATIC_LIB})
+else()
+    target_link_libraries(odin4_lib PRIVATE ${CRYPTOPP_LIBRARIES})
+endif()
+
+# =========================
+# Main executable (C++)
+# =========================
+add_executable(odin4 src/main.cpp)
+set_target_properties(odin4 PROPERTIES OUTPUT_NAME "odin4")
+
+# =========================
+# Compile options
+# =========================
+target_compile_options(odin4_lib PRIVATE -Wall -Wextra -Wno-cast-function-type)
+target_compile_options(odin4 PRIVATE -Wall -Wextra)
+
+# =========================
+# Includes
+# =========================
+target_include_directories(odin4 PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
 
 # =========================
 # Linking
 # =========================
 target_link_libraries(odin4 PRIVATE
-    ${LIBUSB_LIBRARIES}
-    lz4_lib
+    odin4_lib
     -static-libgcc
     -static-libstdc++
 )
-
-if (CRYPTOPP_USE_STATIC)
-    target_link_libraries(odin4 PRIVATE ${CRYPTOPP_STATIC_LIB})
-else()
-    target_link_libraries(odin4 PRIVATE ${CRYPTOPP_LIBRARIES})
-endif()

--- a/include/odin4/odin4.h
+++ b/include/odin4/odin4.h
@@ -1,0 +1,83 @@
+#ifndef ODIN4_H
+#define ODIN4_H
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Exit codes for Odin4 operations.
+ */
+enum class OdinExitCode : int {
+    Success = 0,
+    Usage = 1,
+    Usb = 2,
+    Protocol = 3,
+    Pit = 4,
+    Firmware = 5,
+    Unknown = 99
+};
+
+/**
+ * @brief Configuration for Odin4 operations.
+ */
+struct OdinConfig {
+    std::string bootloader;
+    std::string ap;
+    std::string cp;
+    std::string csc;
+    std::string ums;
+    std::string device_path;
+
+    bool dry_run = false;
+    bool allow_unknown = false;
+    bool reboot = false;
+    bool redownload = false;
+
+    bool quiet = false;
+    bool verbose = false;
+    bool debug = false;
+
+    bool has_vid = false;
+    uint16_t vid = 0;
+    bool has_pid = false;
+    uint16_t pid = 0;
+    bool has_usb_interface = false;
+    int usb_interface = 0;
+};
+
+/**
+ * @brief Initialize the library (e.g., logging).
+ * @param cfg The configuration to use for initialization.
+ */
+void odin4_init(const OdinConfig& cfg);
+
+/**
+ * @brief List detected Samsung devices in Download Mode.
+ * @param cfg The configuration containing USB selection criteria.
+ * @return A list of device paths.
+ */
+std::vector<std::string> odin4_list_devices(const OdinConfig& cfg);
+
+/**
+ * @brief Run the flashing process or validation for a specific device.
+ * @param cfg The configuration for the operation.
+ * @return OdinExitCode indicating success or failure.
+ */
+OdinExitCode odin4_run(const OdinConfig& cfg);
+
+/**
+ * @brief Get the version string of the library.
+ * @return The version string.
+ */
+const char* odin4_get_version();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ODIN4_H

--- a/src/core/odin_types.h
+++ b/src/core/odin_types.h
@@ -15,45 +15,6 @@
 enum class ExitCode : int { Success = 0, Usage = 2, Usb = 3, Firmware = 4, Pit = 5, Protocol = 6 };
 
 // ============================================================================
-// CONFIGURATION STRUCTURES
-// ============================================================================
-
-struct OdinConfig {
-    std::string bootloader;
-    std::string ap;
-    std::string cp;
-    std::string csc;
-    std::string ums;
-    std::string device_path;
-    // Flags controlling optional behaviour
-    bool reboot = false;
-    bool redownload = false;
-    // Perform a dry run (check-only) instead of actually flashing. When
-    // enabled, odin4 will verify firmware integrity and compatibility,
-    // parse PIT tables and tar archives, but will not send any data to
-    // the device. This flag corresponds to the --check-only command-line
-    // option.
-    bool dry_run = false;
-
-    // When enabled, files that do not map to PIT partitions are skipped instead
-    // of causing an abort. This is disabled by default for safety.
-    bool allow_unknown = false;
-
-    // Logging
-    bool quiet = false;
-    bool verbose = false;
-    bool debug = false;
-
-    // Optional USB selection overrides.
-    bool has_vid = false;
-    uint16_t vid = 0;
-    bool has_pid = false;
-    uint16_t pid = 0;
-    bool has_usb_interface = false;
-    int usb_interface = 0;
-};
-
-// ============================================================================
 // PARTITION INFORMATION TABLE (PIT)
 // ============================================================================
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,29 +1,12 @@
-// odin4 - Samsung Device Flashing Tool
-// Protocol: Thor USB Communication
-
 #include <iostream>
 #include <string>
 #include <vector>
-#include <iomanip>
-#include <algorithm>
-#include <cctype>
 #include <filesystem>
-#include <chrono>
-#include <sstream>
-
-#include <libusb.h>
-
-#include "core/logger.h"
-#include "core/odin_types.h"
-#include "protocol/thor_protocol.h"
-#include "usb/usb_device.h"
-#include "firmware/firmware_package.h"
-
-#define ODIN4_VERSION "5.1.0-695053a"
+#include "odin4/odin4.h"
 
 static void print_usage() {
     std::cout << "Usage: odin4 [options]" << std::endl;
-    std::cout << "Samsung firmware flashing tool for Linux. Version: " << ODIN4_VERSION << std::endl;
+    std::cout << "Samsung firmware flashing tool for Linux. Version: " << odin4_get_version() << std::endl;
     std::cout << std::endl;
     std::cout << "Options:" << std::endl;
     std::cout << "  -h                  Show this help message" << std::endl;
@@ -57,7 +40,7 @@ static void print_usage() {
 }
 
 static void print_version() {
-    std::cout << "odin4 version " << ODIN4_VERSION << std::endl;
+    std::cout << "odin4 version " << odin4_get_version() << std::endl;
 }
 
 static void print_license() {
@@ -110,229 +93,23 @@ static bool has_any_firmware_files(const OdinConfig& cfg) {
     return !cfg.bootloader.empty() || !cfg.ap.empty() || !cfg.cp.empty() || !cfg.csc.empty() || !cfg.ums.empty();
 }
 
-static UsbSelectionCriteria criteria_from_config(const OdinConfig& cfg) {
-    UsbSelectionCriteria c;
-    if (cfg.has_vid) {
-        c.has_vid = true;
-        c.vid = cfg.vid;
-    }
-    if (cfg.has_pid) {
-        c.has_pid = true;
-        c.pid = cfg.pid;
-    }
-    if (cfg.has_usb_interface) {
-        c.has_interface = true;
-        c.interface_number = cfg.usb_interface;
-    }
-    return c;
-}
-
-static void list_devices(const UsbSelectionCriteria& criteria) {
-    const std::vector<std::string> devices = UsbDevice::list_download_devices(criteria);
-    if (devices.empty()) {
-        std::cout << "No devices detected in Download Mode." << std::endl;
-        return;
-    }
-    for (const auto& path : devices) {
-        std::cout << path << std::endl;
-    }
-}
-
-static bool verify_firmware_compatibility(const OdinConfig& cfg, const std::string& device_type) {
-    if (device_type.empty()) {
-        log_verbose("Device type is empty; skipping filename compatibility checks.");
-        return true;
-    }
-
-    std::string dt = device_type;
-    dt.erase(std::remove_if(dt.begin(), dt.end(),
-                            [](unsigned char c) { return std::isspace(c) || c == '\\' || c == '/' || c == '-'; }),
-             dt.end());
-
-    std::transform(dt.begin(), dt.end(), dt.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-
-    if (dt.rfind("SM", 0) == 0)
-        dt = dt.substr(2);
-
-    auto file_matches = [&](const std::string& path) -> bool {
-        if (path.empty())
-            return true;
-        std::string fname = std::filesystem::path(path).filename().string();
-        std::string f;
-        f.reserve(fname.size());
-        for (unsigned char c : fname) {
-            if (std::isalnum(c))
-                f.push_back(static_cast<char>(std::toupper(c)));
-        }
-        // If device type is short (e.g. "G991B"), it's likely a model number.
-        // If it's very short, we might want to be less strict.
-        return f.find(dt) != std::string::npos;
-    };
-
-    for (const std::string& p : {cfg.bootloader, cfg.ap, cfg.cp, cfg.csc, cfg.ums}) {
-        if (p.empty())
-            continue;
-        if (!file_matches(p)) {
-            log_error("Firmware file name does not appear to match device type: " +
-                      std::filesystem::path(p).filename().string() + " vs " + device_type);
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static void print_access_hint() {
-    log_error("Permission denied while opening the USB device. This usually means udev rules are missing.");
-    log_info("Install the udev rule shipped with odin4: udev/60-odin4.rules");
-    log_info("Then reload udev rules and reconnect the device.");
-}
-
-static ExitCode run_for_device(const OdinConfig& cfg) {
-    UsbDevice usb;
-    const UsbSelectionCriteria criteria = criteria_from_config(cfg);
-
-    if (!usb.open_device(cfg.device_path, criteria)) {
-        if (usb.get_last_open_error() == UsbOpenError::AccessDenied) {
-            print_access_hint();
-        } else if (usb.get_last_open_error() == UsbOpenError::NotDownloadMode) {
-            log_error("Device detected, but it does not appear to be in Download Mode.");
-        } else {
-            log_error("No compatible device could be opened. Ensure the device is in Download Mode and try again.");
-        }
-        return ExitCode::Usb;
-    }
-
-    if (!usb.handshake()) {
-        log_error("USB handshake failed.");
-        return ExitCode::Protocol;
-    }
-    log_info("Handshake successful.");
-
-    if (!usb.request_device_type()) {
-        log_error("Failed to query device type.");
-        return ExitCode::Protocol;
-    }
-
-    const std::string device_type = usb.get_device_type();
-    if (!device_type.empty())
-        log_info("Device type: " + device_type);
-
-    if (has_any_firmware_files(cfg)) {
-        if (!verify_firmware_compatibility(cfg, device_type)) {
-            return ExitCode::Pit;
-        }
-    }
-
-    if (!usb.begin_session()) {
-        log_error("Failed to begin session.");
-        return ExitCode::Protocol;
-    }
-
-    PitTable pit;
-    if (!usb.request_pit(pit)) {
-        log_error("Failed to retrieve or parse PIT from device.");
-        usb.end_session();
-        return ExitCode::Pit;
-    }
-    log_info("PIT received with " + std::to_string(pit.entries.size()) + " entries.");
-
-    if (has_any_firmware_files(cfg)) {
-        const std::vector<std::pair<std::string, std::string>> archives = {
-            {"BL", cfg.bootloader}, {"AP", cfg.ap}, {"CP", cfg.cp}, {"CSC", cfg.csc}, {"UMS", cfg.ums}};
-
-        if (usb.is_odin_legacy()) {
-            uint64_t total_bytes = 0;
-            for (const auto& item : archives) {
-                if (item.second.empty())
-                    continue;
-                std::error_code ec;
-                auto sz = std::filesystem::file_size(item.second, ec);
-                if (!ec)
-                    total_bytes += sz;
-            }
-            if (total_bytes > 0 && !usb.notify_total_bytes(total_bytes)) {
-                log_error("Failed to send total bytes to device.");
-                usb.end_session();
-                return ExitCode::Protocol;
-            }
-        }
-
-        for (const auto& item : archives) {
-            if (item.second.empty())
-                continue;
-            ExitCode rc = process_tar_file(item.second, usb, pit, !cfg.dry_run, cfg.allow_unknown);
-            if (rc != ExitCode::Success) {
-                usb.end_session();
-                return rc;
-            }
-        }
-    }
-
-    if (!cfg.dry_run) {
-        if (cfg.reboot) {
-            if (!usb.send_control(THOR_CONTROL_REBOOT)) {
-                log_error("Failed to send reboot command.");
-                usb.end_session();
-                return ExitCode::Protocol;
-            }
-        }
-        if (cfg.redownload) {
-            if (!usb.send_control(THOR_CONTROL_REDOWNLOAD)) {
-                log_error("Failed to send redownload command.");
-                usb.end_session();
-                return ExitCode::Protocol;
-            }
-        }
-    } else {
-        if (cfg.reboot || cfg.redownload) {
-            log_verbose("Check-only mode: reboot/redownload commands skipped.");
-        }
-    }
-
-    if (!usb.end_session()) {
-        log_error("Failed to end session.");
-        return ExitCode::Protocol;
-    }
-
-    if (cfg.dry_run) {
-        log_info("Validation completed successfully (check-only).");
-    } else if (has_any_firmware_files(cfg)) {
-        log_info("Flashing completed successfully.");
-    }
-
-    return ExitCode::Success;
-}
-
-static ExitCode process_arguments_and_run(int argc, char** argv) {
+int main(int argc, char** argv) {
     OdinConfig cfg;
-
-    auto apply_log_flags = [&]() {
-        if (cfg.debug)
-            set_log_level(LogLevel::Debug);
-        else if (cfg.verbose)
-            set_log_level(LogLevel::Verbose);
-        else if (cfg.quiet)
-            set_log_level(LogLevel::Error);
-        else
-            set_log_level(LogLevel::Info);
-    };
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
 
         if (arg == "-h") {
             print_usage();
-            return ExitCode::Success;
+            return 0;
         }
         if (arg == "-v") {
             print_version();
-            return ExitCode::Success;
+            return 0;
         }
         if (arg == "-w") {
             print_license();
-            return ExitCode::Success;
+            return 0;
         }
 
         if (arg == "--quiet") {
@@ -392,8 +169,8 @@ static ExitCode process_arguments_and_run(int argc, char** argv) {
         if (arg == "--vid") {
             uint16_t v = 0;
             if (!take_value_u16hex(v)) {
-                log_error("--vid requires a hex value");
-                return ExitCode::Usage;
+                std::cerr << "Error: --vid requires a hex value" << std::endl;
+                return 1;
             }
             cfg.has_vid = true;
             cfg.vid = v;
@@ -402,8 +179,8 @@ static ExitCode process_arguments_and_run(int argc, char** argv) {
         if (arg == "--pid") {
             uint16_t p = 0;
             if (!take_value_u16hex(p)) {
-                log_error("--pid requires a hex value");
-                return ExitCode::Usage;
+                std::cerr << "Error: --pid requires a hex value" << std::endl;
+                return 1;
             }
             cfg.has_pid = true;
             cfg.pid = p;
@@ -412,8 +189,8 @@ static ExitCode process_arguments_and_run(int argc, char** argv) {
         if (arg == "--usb-interface") {
             int n = 0;
             if (!take_value_int(n) || n < 0 || n > 255) {
-                log_error("--usb-interface requires an integer in the range 0..255");
-                return ExitCode::Usage;
+                std::cerr << "Error: --usb-interface requires an integer in the range 0..255" << std::endl;
+                return 1;
             }
             cfg.has_usb_interface = true;
             cfg.usb_interface = n;
@@ -421,16 +198,23 @@ static ExitCode process_arguments_and_run(int argc, char** argv) {
         }
 
         if (arg == "-l") {
-            apply_log_flags();
-            list_devices(criteria_from_config(cfg));
-            return ExitCode::Success;
+            odin4_init(cfg);
+            const std::vector<std::string> devices = odin4_list_devices(cfg);
+            if (devices.empty()) {
+                std::cout << "No devices detected in Download Mode." << std::endl;
+            } else {
+                for (const auto& path : devices) {
+                    std::cout << path << std::endl;
+                }
+            }
+            return 0;
         }
 
         if (arg == "-b" || arg == "-a" || arg == "-c" || arg == "-s" || arg == "-u" || arg == "-d") {
             std::string value;
             if (!take_value(value)) {
-                log_error("Option requires an argument: " + arg);
-                return ExitCode::Usage;
+                std::cerr << "Error: Option requires an argument: " << arg << std::endl;
+                return 1;
             }
             if (arg == "-b")
                 cfg.bootloader = value;
@@ -448,55 +232,29 @@ static ExitCode process_arguments_and_run(int argc, char** argv) {
         }
 
         if (!arg.empty() && arg[0] == '-') {
-            log_error("Unknown option: " + arg);
-            return ExitCode::Usage;
+            std::cerr << "Error: Unknown option: " << arg << std::endl;
+            return 1;
         }
     }
 
-    apply_log_flags();
-    set_log_file("odin4.log");
+    odin4_init(cfg);
 
     if (cfg.dry_run && !has_any_firmware_files(cfg)) {
-        log_error("--check-only requires at least one firmware archive (-b/-a/-c/-s/-u)");
-        return ExitCode::Usage;
+        std::cerr << "Error: --check-only requires at least one firmware archive (-b/-a/-c/-s/-u)" << std::endl;
+        return 1;
     }
 
     if (!has_any_firmware_files(cfg) && !cfg.reboot && !cfg.redownload) {
         print_usage();
-        return ExitCode::Usage;
+        return 1;
     }
 
     for (const auto& path : {cfg.bootloader, cfg.ap, cfg.cp, cfg.csc, cfg.ums}) {
         if (!path.empty() && !std::filesystem::exists(path)) {
-            log_error("Firmware file not found: " + path);
-            return ExitCode::Firmware;
+            std::cerr << "Error: Firmware file not found: " << path << std::endl;
+            return 5; // Firmware error
         }
     }
 
-    const UsbSelectionCriteria criteria = criteria_from_config(cfg);
-
-    if (cfg.device_path.empty()) {
-        const std::vector<std::string> devices = UsbDevice::list_download_devices(criteria);
-        if (devices.empty()) {
-            log_error("No compatible devices detected in Download Mode.");
-            return ExitCode::Usb;
-        }
-        if (devices.size() > 1) {
-            log_error("Multiple compatible devices detected in Download Mode. Use -d to select one device.");
-            for (const auto& dev_path : devices)
-                log_info("Detected device: " + dev_path);
-            return ExitCode::Usb;
-        }
-        OdinConfig one = cfg;
-        one.device_path = devices.front();
-        log_info("Using device: " + one.device_path);
-        return run_for_device(one);
-    }
-
-    return run_for_device(cfg);
-}
-
-int main(int argc, char** argv) {
-    const ExitCode rc = process_arguments_and_run(argc, argv);
-    return static_cast<int>(rc);
+    return static_cast<int>(odin4_run(cfg));
 }

--- a/src/odin4.cpp
+++ b/src/odin4.cpp
@@ -1,0 +1,241 @@
+#include "odin4/odin4.h"
+#include "core/logger.h"
+#include "core/odin_types.h"
+#include "protocol/thor_protocol.h"
+#include "usb/usb_device.h"
+#include "firmware/firmware_package.h"
+
+#include <iostream>
+#include <algorithm>
+#include <filesystem>
+
+#define ODIN4_VERSION "5.1.0-695053a"
+
+const char* odin4_get_version() {
+    return ODIN4_VERSION;
+}
+
+static UsbSelectionCriteria criteria_from_config(const OdinConfig& cfg) {
+    UsbSelectionCriteria c;
+    if (cfg.has_vid) {
+        c.has_vid = true;
+        c.vid = cfg.vid;
+    }
+    if (cfg.has_pid) {
+        c.has_pid = true;
+        c.pid = cfg.pid;
+    }
+    if (cfg.has_usb_interface) {
+        c.has_interface = true;
+        c.interface_number = cfg.usb_interface;
+    }
+    return c;
+}
+
+void odin4_init(const OdinConfig& cfg) {
+    if (cfg.debug)
+        set_log_level(LogLevel::Debug);
+    else if (cfg.verbose)
+        set_log_level(LogLevel::Verbose);
+    else if (cfg.quiet)
+        set_log_level(LogLevel::Error);
+    else
+        set_log_level(LogLevel::Info);
+    
+    set_log_file("odin4.log");
+}
+
+std::vector<std::string> odin4_list_devices(const OdinConfig& cfg) {
+    return UsbDevice::list_download_devices(criteria_from_config(cfg));
+}
+
+static bool has_any_firmware_files(const OdinConfig& cfg) {
+    return !cfg.bootloader.empty() || !cfg.ap.empty() || !cfg.cp.empty() || !cfg.csc.empty() || !cfg.ums.empty();
+}
+
+static bool verify_firmware_compatibility(const OdinConfig& cfg, const std::string& device_type) {
+    if (device_type.empty()) {
+        log_verbose("Device type is empty; skipping filename compatibility checks.");
+        return true;
+    }
+
+    std::string dt = device_type;
+    dt.erase(std::remove_if(dt.begin(), dt.end(),
+                            [](unsigned char c) { return std::isspace(c) || c == '\\' || c == '/' || c == '-'; }),
+             dt.end());
+
+    std::transform(dt.begin(), dt.end(), dt.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+    if (dt.rfind("SM", 0) == 0)
+        dt = dt.substr(2);
+
+    auto file_matches = [&](const std::string& path) -> bool {
+        if (path.empty())
+            return true;
+        std::string fname = std::filesystem::path(path).filename().string();
+        std::string f;
+        f.reserve(fname.size());
+        for (unsigned char c : fname) {
+            if (std::isalnum(c))
+                f.push_back(static_cast<char>(std::toupper(c)));
+        }
+        return f.find(dt) != std::string::npos;
+    };
+
+    for (const std::string& p : {cfg.bootloader, cfg.ap, cfg.cp, cfg.csc, cfg.ums}) {
+        if (p.empty())
+            continue;
+        if (!file_matches(p)) {
+            log_error("Firmware file name does not appear to match device type: " +
+                      std::filesystem::path(p).filename().string() + " vs " + device_type);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void print_access_hint() {
+    log_error("Permission denied while opening the USB device. This usually means udev rules are missing.");
+    log_info("Install the udev rule shipped with odin4: udev/60-odin4.rules");
+    log_info("Then reload udev rules and reconnect the device.");
+}
+
+static OdinExitCode run_for_device(const OdinConfig& cfg) {
+    UsbDevice usb;
+    const UsbSelectionCriteria criteria = criteria_from_config(cfg);
+
+    if (!usb.open_device(cfg.device_path, criteria)) {
+        if (usb.get_last_open_error() == UsbOpenError::AccessDenied) {
+            print_access_hint();
+        } else if (usb.get_last_open_error() == UsbOpenError::NotDownloadMode) {
+            log_error("Device detected, but it does not appear to be in Download Mode.");
+        } else {
+            log_error("No compatible device could be opened. Ensure the device is in Download Mode and try again.");
+        }
+        return OdinExitCode::Usb;
+    }
+
+    if (!usb.handshake()) {
+        log_error("USB handshake failed.");
+        return OdinExitCode::Protocol;
+    }
+    log_info("Handshake successful.");
+
+    if (!usb.request_device_type()) {
+        log_error("Failed to query device type.");
+        return OdinExitCode::Protocol;
+    }
+
+    const std::string device_type = usb.get_device_type();
+    if (!device_type.empty())
+        log_info("Device type: " + device_type);
+
+    if (has_any_firmware_files(cfg)) {
+        if (!verify_firmware_compatibility(cfg, device_type)) {
+            return OdinExitCode::Pit;
+        }
+    }
+
+    if (!usb.begin_session()) {
+        log_error("Failed to begin session.");
+        return OdinExitCode::Protocol;
+    }
+
+    PitTable pit;
+    if (!usb.request_pit(pit)) {
+        log_error("Failed to retrieve or parse PIT from device.");
+        usb.end_session();
+        return OdinExitCode::Pit;
+    }
+    log_info("PIT received with " + std::to_string(pit.entries.size()) + " entries.");
+
+    if (has_any_firmware_files(cfg)) {
+        const std::vector<std::pair<std::string, std::string>> archives = {
+            {"BL", cfg.bootloader}, {"AP", cfg.ap}, {"CP", cfg.cp}, {"CSC", cfg.csc}, {"UMS", cfg.ums}};
+
+        if (usb.is_odin_legacy()) {
+            uint64_t total_bytes = 0;
+            for (const auto& item : archives) {
+                if (item.second.empty())
+                    continue;
+                std::error_code ec;
+                auto sz = std::filesystem::file_size(item.second, ec);
+                if (!ec)
+                    total_bytes += sz;
+            }
+            if (total_bytes > 0 && !usb.notify_total_bytes(total_bytes)) {
+                log_error("Failed to send total bytes to device.");
+                usb.end_session();
+                return OdinExitCode::Protocol;
+            }
+        }
+
+        for (const auto& item : archives) {
+            if (item.second.empty())
+                continue;
+            ExitCode rc = process_tar_file(item.second, usb, pit, !cfg.dry_run, cfg.allow_unknown);
+            if (rc != ExitCode::Success) {
+                usb.end_session();
+                return static_cast<OdinExitCode>(rc);
+            }
+        }
+    }
+
+    if (!cfg.dry_run) {
+        if (cfg.reboot) {
+            if (!usb.send_control(THOR_CONTROL_REBOOT)) {
+                log_error("Failed to send reboot command.");
+                usb.end_session();
+                return OdinExitCode::Protocol;
+            }
+        }
+        if (cfg.redownload) {
+            if (!usb.send_control(THOR_CONTROL_REDOWNLOAD)) {
+                log_error("Failed to send redownload command.");
+                usb.end_session();
+                return OdinExitCode::Protocol;
+            }
+        }
+    } else {
+        if (cfg.reboot || cfg.redownload) {
+            log_verbose("Check-only mode: reboot/redownload commands skipped.");
+        }
+    }
+
+    if (!usb.end_session()) {
+        log_error("Failed to end session.");
+        return OdinExitCode::Protocol;
+    }
+
+    if (cfg.dry_run) {
+        log_info("Validation completed successfully (check-only).");
+    } else if (has_any_firmware_files(cfg)) {
+        log_info("Flashing completed successfully.");
+    }
+
+    return OdinExitCode::Success;
+}
+
+OdinExitCode odin4_run(const OdinConfig& cfg) {
+    if (cfg.device_path.empty()) {
+        const std::vector<std::string> devices = UsbDevice::list_download_devices(criteria_from_config(cfg));
+        if (devices.empty()) {
+            log_error("No compatible devices detected in Download Mode.");
+            return OdinExitCode::Usb;
+        }
+        if (devices.size() > 1) {
+            log_error("Multiple compatible devices detected in Download Mode. Use -d to select one device.");
+            for (const auto& dev_path : devices)
+                log_info("Detected device: " + dev_path);
+            return OdinExitCode::Usb;
+        }
+        OdinConfig one = cfg;
+        one.device_path = devices.front();
+        log_info("Using device: " + one.device_path);
+        return run_for_device(one);
+    }
+
+    return run_for_device(cfg);
+}


### PR DESCRIPTION
This PR refactors the project to separate the core functionality into a shared library (libodin4) and a CLI tool (odin4).

Key changes:
- Created a public API header under include/odin4/odin4.h.
- Moved reusable logic from main.cpp to src/odin4.cpp.
- Updated CMakeLists.txt to build both the shared library and the CLI.
- Updated GitHub Actions workflow to build and upload both targets as artifacts.
- Maintained original CLI behavior and usage.
- Ensured proper encapsulation and clean builds on Linux.

Credits: Llucs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored build system to produce and distribute a shared library alongside the executable for enhanced integration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->