### PR TITLE
Add Qt6 GUI and update workflow for GUI/Library builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,10 @@ jobs:
             g++ \
             git \
             libusb-1.0-0-dev \
-            libcrypto++-dev
+            libcrypto++-dev \
+            qt6-base-dev \
+            libqt6widgets6 \
+            libgl1-mesa-dev
 
       - name: Ensure Crypto++ static library is available
         shell: bash
@@ -93,7 +96,9 @@ jobs:
           echo "ODIN4_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "ODIN4_SUFFIX=$SUFFIX" >> "$GITHUB_ENV"
           echo "ODIN4_OUTNAME=odin4_${{ matrix.arch }}_${VERSION}${SUFFIX}" >> "$GITHUB_ENV"
+          echo "ODIN4_GUI_OUTNAME=odin4-gui_${{ matrix.arch }}_${VERSION}${SUFFIX}" >> "$GITHUB_ENV"
           echo "LIB_OUTNAME=libodin4_${{ matrix.arch }}_${VERSION}${SUFFIX}.so" >> "$GITHUB_ENV"
+          echo "LIB_STATIC_OUTNAME=libodin4_${{ matrix.arch }}_${VERSION}${SUFFIX}.a" >> "$GITHUB_ENV"
 
       - name: Clean build dir
         shell: bash
@@ -120,15 +125,15 @@ jobs:
         run: |
           set -euo pipefail
           BIN="build/odin4"
+          GUI="build/odin4-gui"
           LIB="build/libodin4.so"
-          if [ ! -f "$BIN" ]; then
-            echo "ERROR: build/odin4 not found." >&2
-            exit 1
-          fi
-          if [ ! -f "$LIB" ]; then
-            echo "ERROR: build/libodin4.so not found." >&2
-            exit 1
-          fi
+          LIB_STATIC="build/libodin4_static.a"
+          for f in "$BIN" "$GUI" "$LIB" "$LIB_STATIC"; do
+            if [ ! -f "$f" ]; then
+              echo "ERROR: $f not found." >&2
+              exit 1
+            fi
+          done
           # The CLI now depends on libodin4.so, but we want to ensure it doesn't depend on libcrypto++.so directly
           if ldd "$BIN" | grep -qiE 'libcrypto\+\+\.so'; then
             echo "ERROR: Binary still depends on libcrypto++.so." >&2
@@ -141,13 +146,17 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           cp build/odin4 "dist/${ODIN4_OUTNAME}"
+          cp build/odin4-gui "dist/${ODIN4_GUI_OUTNAME}"
           cp build/libodin4.so "dist/${LIB_OUTNAME}"
+          cp build/libodin4_static.a "dist/${LIB_STATIC_OUTNAME}"
           strip "dist/${ODIN4_OUTNAME}" || true
+          strip "dist/${ODIN4_GUI_OUTNAME}" || true
           strip "dist/${LIB_OUTNAME}" || true
+          # Note: don't strip static libs
           ZIP_NAME="odin4-linux-${{ matrix.arch }}-${ODIN4_VERSION}${ODIN4_SUFFIX}.zip"
           (
             cd dist
-            zip "../${ZIP_NAME}" "${ODIN4_OUTNAME}" "${LIB_OUTNAME}"
+            zip "../${ZIP_NAME}" "${ODIN4_OUTNAME}" "${ODIN4_GUI_OUTNAME}" "${LIB_OUTNAME}" "${LIB_STATIC_OUTNAME}"
           )
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,17 @@ set_target_properties(odin4 PROPERTIES OUTPUT_NAME "odin4")
 target_include_directories(odin4 PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(odin4 PRIVATE odin4_static -static-libgcc -static-libstdc++)
 
-foreach(target odin4_static odin4_shared odin4)
+# GUI Target
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+add_executable(odin4-gui src-gui/main.cpp)
+set_target_properties(odin4-gui PROPERTIES 
+    OUTPUT_NAME "odin4-gui"
+    AUTOMOC ON
+)
+target_include_directories(odin4-gui PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(odin4-gui PRIVATE odin4_static Qt6::Widgets)
+
+foreach(target odin4_static odin4_shared odin4 odin4-gui)
     target_compile_options(${target} PRIVATE -Wall -Wextra -Wno-cast-function-type)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         target_compile_options(${target} PRIVATE -fstack-protector-strong -D_FORTIFY_SOURCE=2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,21 +86,27 @@ set_target_properties(odin4 PROPERTIES OUTPUT_NAME "odin4")
 target_include_directories(odin4 PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(odin4 PRIVATE odin4_static -static-libgcc -static-libstdc++)
 
-# GUI Target
-find_package(Qt6 COMPONENTS Widgets REQUIRED)
-add_executable(odin4-gui src-gui/main.cpp)
-set_target_properties(odin4-gui PROPERTIES 
-    OUTPUT_NAME "odin4-gui"
-    AUTOMOC ON
-)
-target_include_directories(odin4-gui PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(odin4-gui PRIVATE odin4_static Qt6::Widgets)
+# Optional GUI build
+option(ODIN4_BUILD_GUI "Build Qt6 GUI target" ON)
+set(ODIN4_ALL_TARGETS odin4_static odin4_shared odin4)
 
-if(NOT MSVC)
-    target_link_options(odin4-gui PRIVATE "-static-libgcc" "-static-libstdc++")
+# GUI Target
+if(ODIN4_BUILD_GUI)
+    find_package(Qt6 COMPONENTS Widgets REQUIRED)
+    add_executable(odin4-gui src-gui/main.cpp)
+    set_target_properties(odin4-gui PROPERTIES
+        OUTPUT_NAME "odin4-gui"
+        AUTOMOC ON
+    )
+    target_include_directories(odin4-gui PRIVATE ${CMAKE_SOURCE_DIR}/include)
+    target_link_libraries(odin4-gui PRIVATE odin4_static Qt6::Widgets)
+    if(NOT MSVC)
+        target_link_options(odin4-gui PRIVATE "-static-libgcc" "-static-libstdc++")
+    endif()
+    list(APPEND ODIN4_ALL_TARGETS odin4-gui)
 endif()
 
-foreach(target odin4_static odin4_shared odin4 odin4-gui)
+foreach(target ${ODIN4_ALL_TARGETS})
     target_compile_options(${target} PRIVATE -Wall -Wextra -Wno-cast-function-type)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         target_compile_options(${target} PRIVATE -fstack-protector-strong -D_FORTIFY_SOURCE=2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,10 @@ set_target_properties(odin4-gui PROPERTIES
 target_include_directories(odin4-gui PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(odin4-gui PRIVATE odin4_static Qt6::Widgets)
 
+if(NOT MSVC)
+    target_link_options(odin4-gui PRIVATE "-static-libgcc" "-static-libstdc++")
+endif()
+
 foreach(target odin4_static odin4_shared odin4 odin4-gui)
     target_compile_options(${target} PRIVATE -Wall -Wextra -Wno-cast-function-type)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/include/odin4/odin4.h
+++ b/include/odin4/odin4.h
@@ -68,6 +68,13 @@ auto odin4_run(const OdinConfig& cfg) -> OdinExitCode;
  */
 auto odin4_get_version() -> const char*;
 
+/**
+ * @brief Set a callback function to receive log messages.
+ * @param callback The function to call for each log message.
+ */
+typedef void (*OdinLogCallback)(int level, const char* message);
+void odin4_set_log_callback(OdinLogCallback callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src-gui/main.cpp
+++ b/src-gui/main.cpp
@@ -11,14 +11,34 @@
 #include <QComboBox>
 #include <QMessageBox>
 #include <QTimer>
+#include <QThread>
+#include <QCloseEvent>
 #include <odin4/odin4.h>
-#include <thread>
 #include <mutex>
+
+class FlashWorker : public QObject {
+    Q_OBJECT
+public:
+    FlashWorker(const OdinConfig &cfg) : m_cfg(cfg) {}
+
+public slots:
+    void process() {
+        odin4_init(m_cfg);
+        OdinExitCode result = odin4_run(m_cfg);
+        emit finished(result);
+    }
+
+signals:
+    void finished(OdinExitCode result);
+
+private:
+    OdinConfig m_cfg;
+};
 
 class OdinGui : public QMainWindow {
     Q_OBJECT
 public:
-    OdinGui(QWidget *parent = nullptr) : QMainWindow(parent) {
+    OdinGui(QWidget *parent = nullptr) : QMainWindow(parent), flashThread(nullptr) {
         setWindowTitle("Odin4 GUI - Llucs");
         setMinimumSize(700, 500);
 
@@ -71,14 +91,12 @@ public:
 
         setCentralWidget(centralWidget);
         
-        // Setup log callback
         odin4_set_log_callback([](int level, const char* message) {
             QString msg = QString("[%1] %2").arg(level).arg(message);
-            // Post to UI thread
             QMetaObject::invokeMethod(qApp, [msg]() {
                 auto *win = qobject_cast<OdinGui*>(qApp->activeWindow());
                 if (win) win->appendLog(msg);
-            });
+            }, Qt::QueuedConnection);
         });
 
         refreshDevices();
@@ -86,6 +104,20 @@ public:
 
     void appendLog(const QString &msg) {
         logView->append(msg);
+    }
+
+protected:
+    void closeEvent(QCloseEvent *event) override {
+        if (flashThread && flashThread->isRunning()) {
+            auto ret = QMessageBox::question(this, "Exit", "A flash process is currently running. Are you sure you want to exit?", QMessageBox::Yes | QMessageBox::No);
+            if (ret == QMessageBox::No) {
+                event->ignore();
+                return;
+            }
+            flashThread->quit();
+            flashThread->wait();
+        }
+        event->accept();
     }
 
 private slots:
@@ -123,21 +155,30 @@ private slots:
         logView->append("--- Starting Flash Process ---");
         progressBar->setRange(0, 0);
 
-        std::thread([this, cfg]() {
-            odin4_init(cfg);
-            auto result = odin4_run(cfg);
-            QMetaObject::invokeMethod(this, [this, result]() {
-                btnStart->setEnabled(true);
-                progressBar->setRange(0, 100);
-                if (result == OdinExitCode::Success) {
-                    logView->append("<b>Flash successful!</b>");
-                    progressBar->setValue(100);
-                } else {
-                    logView->append(QString("<span style='color:red;'>Flash failed with code: %1</span>").arg(static_cast<int>(result)));
-                    progressBar->setValue(0);
-                }
-            });
-        }).detach();
+        flashThread = new QThread(this);
+        auto *worker = new FlashWorker(cfg);
+        worker->moveToThread(flashThread);
+
+        connect(flashThread, &QThread::started, worker, &FlashWorker::process);
+        connect(worker, &FlashWorker::finished, this, &OdinGui::onFlashFinished);
+        connect(worker, &FlashWorker::finished, flashThread, &QThread::quit);
+        connect(worker, &FlashWorker::finished, worker, &FlashWorker::deleteLater);
+        connect(flashThread, &QThread::finished, flashThread, &QThread::deleteLater);
+
+        flashThread->start();
+    }
+
+    void onFlashFinished(OdinExitCode result) {
+        btnStart->setEnabled(true);
+        progressBar->setRange(0, 100);
+        if (result == OdinExitCode::Success) {
+            logView->append("<b>Flash successful!</b>");
+            progressBar->setValue(100);
+        } else {
+            logView->append(QString("<span style='color:red;'>Flash failed with code: %1</span>").arg(static_cast<int>(result)));
+            progressBar->setValue(0);
+        }
+        flashThread = nullptr;
     }
 
 private:
@@ -146,6 +187,7 @@ private:
     QTextEdit *logView;
     QProgressBar *progressBar;
     QPushButton *btnStart;
+    QThread *flashThread;
 };
 
 int main(int argc, char *argv[]) {

--- a/src-gui/main.cpp
+++ b/src-gui/main.cpp
@@ -13,28 +13,29 @@
 #include <QTimer>
 #include <odin4/odin4.h>
 #include <thread>
+#include <mutex>
 
 class OdinGui : public QMainWindow {
     Q_OBJECT
 public:
     OdinGui(QWidget *parent = nullptr) : QMainWindow(parent) {
         setWindowTitle("Odin4 GUI - Llucs");
-        setMinimumSize(600, 450);
+        setMinimumSize(700, 500);
 
         auto *centralWidget = new QWidget(this);
         auto *layout = new QVBoxLayout(centralWidget);
 
         auto createBrowseRow = [&](const QString &label, QLineEdit *&edit) {
             auto *row = new QHBoxLayout();
-            row->addWidget(new QLabel(label + ":"));
+            row->addWidget(new QLabel(label + ":"), 0);
             edit = new QLineEdit();
-            row->addWidget(edit);
+            row->addWidget(edit, 1);
             auto *btn = new QPushButton("Browse");
             connect(btn, &QPushButton::clicked, [this, edit]() {
                 QString file = QFileDialog::getOpenFileName(this, "Select File", "", "Samsung Firmware (*.tar *.tar.md5 *.lz4 *.bin)");
                 if (!file.isEmpty()) edit->setText(file);
             });
-            row->addWidget(btn);
+            row->addWidget(btn, 0);
             layout->addLayout(row);
         };
 
@@ -55,19 +56,36 @@ public:
 
         logView = new QTextEdit();
         logView->setReadOnly(true);
+        logView->setStyleSheet("background-color: #1e1e1e; color: #d4d4d4; font-family: monospace;");
         layout->addWidget(logView);
 
         progressBar = new QProgressBar();
         layout->addWidget(progressBar);
 
         auto *btnRow = new QHBoxLayout();
-        btnStart = new QPushButton("Start");
+        btnStart = new QPushButton("Start Flash");
+        btnStart->setMinimumHeight(40);
         connect(btnStart, &QPushButton::clicked, this, &OdinGui::startFlash);
         btnRow->addWidget(btnStart);
         layout->addLayout(btnRow);
 
         setCentralWidget(centralWidget);
+        
+        // Setup log callback
+        odin4_set_log_callback([](int level, const char* message) {
+            QString msg = QString("[%1] %2").arg(level).arg(message);
+            // Post to UI thread
+            QMetaObject::invokeMethod(qApp, [msg]() {
+                auto *win = qobject_cast<OdinGui*>(qApp->activeWindow());
+                if (win) win->appendLog(msg);
+            });
+        });
+
         refreshDevices();
+    }
+
+    void appendLog(const QString &msg) {
+        logView->append(msg);
     }
 
 private slots:
@@ -95,8 +113,14 @@ private slots:
             return;
         }
 
+        if (cfg.device_path == "No device detected") {
+            QMessageBox::warning(this, "Error", "No device selected.");
+            return;
+        }
+
         btnStart->setEnabled(false);
-        logView->append("Starting flash process...");
+        logView->clear();
+        logView->append("--- Starting Flash Process ---");
         progressBar->setRange(0, 0);
 
         std::thread([this, cfg]() {
@@ -106,10 +130,10 @@ private slots:
                 btnStart->setEnabled(true);
                 progressBar->setRange(0, 100);
                 if (result == OdinExitCode::Success) {
-                    logView->append("Flash successful!");
+                    logView->append("<b>Flash successful!</b>");
                     progressBar->setValue(100);
                 } else {
-                    logView->append("Flash failed with code: " + QString::number(static_cast<int>(result)));
+                    logView->append(QString("<span style='color:red;'>Flash failed with code: %1</span>").arg(static_cast<int>(result)));
                     progressBar->setValue(0);
                 }
             });

--- a/src-gui/main.cpp
+++ b/src-gui/main.cpp
@@ -94,8 +94,16 @@ public:
         odin4_set_log_callback([](int level, const char* message) {
             QString msg = QString("[%1] %2").arg(level).arg(message);
             QMetaObject::invokeMethod(qApp, [msg]() {
-                auto *win = qobject_cast<OdinGui*>(qApp->activeWindow());
-                if (win) win->appendLog(msg);
+                for (auto *widget : qApp->topLevelWidgets()) {
+                    if (auto *win = qobject_cast<OdinGui*>(widget)) {
+                        win->appendLog(msg);
+                        return;
+                    }
+                }
+                // Fallback to active window if OdinGui instance not found in topLevelWidgets
+                if (auto *win = qobject_cast<OdinGui*>(qApp->activeWindow())) {
+                    win->appendLog(msg);
+                }
             }, Qt::QueuedConnection);
         });
 

--- a/src-gui/main.cpp
+++ b/src-gui/main.cpp
@@ -1,0 +1,134 @@
+#include <QApplication>
+#include <QMainWindow>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QLabel>
+#include <QFileDialog>
+#include <QProgressBar>
+#include <QTextEdit>
+#include <QComboBox>
+#include <QMessageBox>
+#include <QTimer>
+#include <odin4/odin4.h>
+#include <thread>
+
+class OdinGui : public QMainWindow {
+    Q_OBJECT
+public:
+    OdinGui(QWidget *parent = nullptr) : QMainWindow(parent) {
+        setWindowTitle("Odin4 GUI - Llucs");
+        setMinimumSize(600, 450);
+
+        auto *centralWidget = new QWidget(this);
+        auto *layout = new QVBoxLayout(centralWidget);
+
+        auto createBrowseRow = [&](const QString &label, QLineEdit *&edit) {
+            auto *row = new QHBoxLayout();
+            row->addWidget(new QLabel(label + ":"));
+            edit = new QLineEdit();
+            row->addWidget(edit);
+            auto *btn = new QPushButton("Browse");
+            connect(btn, &QPushButton::clicked, [this, edit]() {
+                QString file = QFileDialog::getOpenFileName(this, "Select File", "", "Samsung Firmware (*.tar *.tar.md5 *.lz4 *.bin)");
+                if (!file.isEmpty()) edit->setText(file);
+            });
+            row->addWidget(btn);
+            layout->addLayout(row);
+        };
+
+        createBrowseRow("BL", editBL);
+        createBrowseRow("AP", editAP);
+        createBrowseRow("CP", editCP);
+        createBrowseRow("CSC", editCSC);
+        createBrowseRow("UMS", editUMS);
+
+        auto *devRow = new QHBoxLayout();
+        devRow->addWidget(new QLabel("Device:"));
+        comboDevices = new QComboBox();
+        devRow->addWidget(comboDevices, 1);
+        auto *btnRefresh = new QPushButton("Refresh");
+        connect(btnRefresh, &QPushButton::clicked, this, &OdinGui::refreshDevices);
+        devRow->addWidget(btnRefresh);
+        layout->addLayout(devRow);
+
+        logView = new QTextEdit();
+        logView->setReadOnly(true);
+        layout->addWidget(logView);
+
+        progressBar = new QProgressBar();
+        layout->addWidget(progressBar);
+
+        auto *btnRow = new QHBoxLayout();
+        btnStart = new QPushButton("Start");
+        connect(btnStart, &QPushButton::clicked, this, &OdinGui::startFlash);
+        btnRow->addWidget(btnStart);
+        layout->addLayout(btnRow);
+
+        setCentralWidget(centralWidget);
+        refreshDevices();
+    }
+
+private slots:
+    void refreshDevices() {
+        comboDevices->clear();
+        OdinConfig cfg;
+        auto devices = odin4_list_devices(cfg);
+        for (const auto &dev : devices) {
+            comboDevices->addItem(QString::fromStdString(dev));
+        }
+        if (devices.empty()) comboDevices->addItem("No device detected");
+    }
+
+    void startFlash() {
+        OdinConfig cfg;
+        cfg.bootloader = editBL->text().toStdString();
+        cfg.ap = editAP->text().toStdString();
+        cfg.cp = editCP->text().toStdString();
+        cfg.csc = editCSC->text().toStdString();
+        cfg.ums = editUMS->text().toStdString();
+        cfg.device_path = comboDevices->currentText().toStdString();
+
+        if (cfg.bootloader.empty() && cfg.ap.empty() && cfg.cp.empty() && cfg.csc.empty() && cfg.ums.empty()) {
+            QMessageBox::warning(this, "Error", "Please select at least one file to flash.");
+            return;
+        }
+
+        btnStart->setEnabled(false);
+        logView->append("Starting flash process...");
+        progressBar->setRange(0, 0);
+
+        std::thread([this, cfg]() {
+            odin4_init(cfg);
+            auto result = odin4_run(cfg);
+            QMetaObject::invokeMethod(this, [this, result]() {
+                btnStart->setEnabled(true);
+                progressBar->setRange(0, 100);
+                if (result == OdinExitCode::Success) {
+                    logView->append("Flash successful!");
+                    progressBar->setValue(100);
+                } else {
+                    logView->append("Flash failed with code: " + QString::number(static_cast<int>(result)));
+                    progressBar->setValue(0);
+                }
+            });
+        }).detach();
+    }
+
+private:
+    QLineEdit *editBL, *editAP, *editCP, *editCSC, *editUMS;
+    QComboBox *comboDevices;
+    QTextEdit *logView;
+    QProgressBar *progressBar;
+    QPushButton *btnStart;
+};
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    OdinGui gui;
+    gui.show();
+    return app.exec();
+}
+
+#include "main.moc"

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -86,15 +86,19 @@ void write_to_file(LogLevel lvl, const std::string& msg) {
 }
 
 void log_impl(LogLevel lvl, const std::string& msg, bool to_stderr) {
+    LogCallback cb = nullptr;
     if (should_emit(lvl)) {
         if (to_stderr) {
             write_line(std::cerr, lvl, msg);
         } else {
             write_line(std::cout, lvl, msg);
         }
-        std::lock_guard<std::mutex> lock(g_log_mutex);
-        if (g_callback) {
-            g_callback(lvl, msg);
+        {
+            std::lock_guard<std::mutex> lock(g_log_mutex);
+            cb = g_callback;
+        }
+        if (cb) {
+            cb(lvl, msg);
         }
     }
     write_to_file(lvl, msg);

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -29,6 +29,7 @@ namespace {
 std::ofstream g_log_stream;
 std::mutex g_log_mutex;
 LogLevel g_level = LogLevel::Info;
+LogCallback g_callback = nullptr;
 
 auto timestamp_now() -> std::string {
     using namespace std::chrono;
@@ -91,10 +92,19 @@ void log_impl(LogLevel lvl, const std::string& msg, bool to_stderr) {
         } else {
             write_line(std::cout, lvl, msg);
         }
+        std::lock_guard<std::mutex> lock(g_log_mutex);
+        if (g_callback) {
+            g_callback(lvl, msg);
+        }
     }
     write_to_file(lvl, msg);
 }
 } // namespace
+
+void set_log_callback(LogCallback cb) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    g_callback = std::move(cb);
+}
 
 void set_log_level(LogLevel level) {
     g_level = level;

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -19,8 +19,12 @@
 
 #include <string>
 #include <cstddef>
+#include <functional>
 
 enum class LogLevel : int { Error = 0, Warn = 1, Info = 2, Verbose = 3, Debug = 4 };
+
+using LogCallback = std::function<void(LogLevel, const std::string&)>;
+void set_log_callback(LogCallback cb);
 
 // Configure the console/file verbosity. Errors are always printed.
 void set_log_level(LogLevel level);

--- a/src/odin4.cpp
+++ b/src/odin4.cpp
@@ -31,6 +31,16 @@ auto odin4_get_version() -> const char* {
     return ODIN4_VERSION;
 }
 
+void odin4_set_log_callback(OdinLogCallback callback) {
+    if (callback) {
+        set_log_callback([callback](LogLevel level, const std::string& message) {
+            callback(static_cast<int>(level), message.c_str());
+        });
+    } else {
+        set_log_callback(nullptr);
+    }
+}
+
 static auto criteria_from_config(const OdinConfig& cfg) -> UsbSelectionCriteria {
     UsbSelectionCriteria c;
     if (cfg.has_vid) {


### PR DESCRIPTION
This PR introduces a new Qt6-based GUI in `src-gui`, updates the `CMakeLists.txt` to include the GUI target, and modifies the GitHub Actions workflow to generate CLI, GUI, and library (static and shared) versions for both x86_64 and arm64 architectures.

Credits: Llucs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qt-based GUI: browse/select firmware, pick device, start/stop flashing, view progress and live HTML-formatted logs with safe stop/confirmation on close.
  * Logging callback API: external tools can receive live log messages for UI or integration.

* **Chores**
  * Build & packaging updated to produce and include CLI, GUI, shared and static library artifacts and enable Qt6 support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/44)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->