### PR TITLE
Modernize project to C++23 standards

### DIFF
--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <sstream>
 #include <chrono>
+#include <print>
 #include <libusb.h>
 
 namespace {
@@ -73,7 +74,7 @@ auto should_emit(LogLevel lvl) -> bool {
 }
 
 void write_line(std::ostream& os, LogLevel lvl, const std::string& msg) {
-    os << timestamp_now() << " [" << level_tag(lvl) << "] " << msg << '\n';
+    std::println(os, "{} [{}] {}", timestamp_now(), level_tag(lvl), msg);
 }
 
 void write_to_file(LogLevel lvl, const std::string& msg) {
@@ -126,7 +127,7 @@ void set_log_file(const std::string& path) {
     if (!path.empty()) {
         g_log_stream.open(path, std::ios::app);
         if (!g_log_stream) {
-            std::cerr << timestamp_now() << " [ERROR] Unable to open log file: " << path << '\n';
+            std::println(std::cerr, "{} [ERROR] Unable to open log file: {}", timestamp_now(), path);
         }
     }
 }

--- a/src/firmware/firmware_package.cpp
+++ b/src/firmware/firmware_package.cpp
@@ -20,11 +20,15 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <ranges>
+#include <span>
 #include <cstring>
 #include <cctype>
 #include <unordered_set>
 #include <sstream>
 #include <limits>
+#include <format>
+#include <print>
 #include <lz4frame.h>
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
@@ -43,15 +47,7 @@ auto is_hex_char(unsigned char c) -> bool {
 }
 
 auto is_hex32(const std::string& s) -> bool {
-    if (s.size() != 32) {
-        return false;
-    }
-    for (unsigned char c : s) {
-        if (!is_hex_char(c)) {
-            return false;
-        }
-    }
-    return true;
+    return s.size() == 32 && std::ranges::all_of(s, [](unsigned char c) { return is_hex_char(c); });
 }
 
 auto to_lower_copy(std::string s) -> std::string {
@@ -63,7 +59,7 @@ auto ends_with_case_insensitive(const std::string& s, const std::string& suffix)
     if (s.size() < suffix.size()) {
         return false;
     }
-    return to_lower_copy(s.substr(s.size() - suffix.size())) == to_lower_copy(suffix);
+    return to_lower_copy(s).ends_with(to_lower_copy(suffix));
 }
 
 auto tar_field_string(const char* field, size_t max_len) -> std::string {
@@ -124,14 +120,14 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
     info = TarMd5Info{};
 
     std::ifstream file(file_path, std::ios::binary | std::ios::ate);
-    if (!file) {
-        log_error("Could not open file: " + file_path);
+        if (!file) {
+        log_error(std::format("Could not open file: {}", file_path));
         return ExitCode::Firmware;
     }
 
     const std::streampos sp = file.tellg();
     if (sp < 0) {
-        log_error("Failed to determine file size: " + file_path);
+        log_error(std::format("Failed to determine file size: {}", file_path));
         return ExitCode::Firmware;
     }
     const auto file_size = static_cast<uint64_t>(sp);
@@ -144,7 +140,7 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
     }
 
     if (file_size < 32) {
-        log_error("File too small to contain an MD5 trailer: " + file_path);
+        log_error(std::format("File too small to contain an MD5 trailer: {}", file_path));
         return ExitCode::Firmware;
     }
 
@@ -153,7 +149,7 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
 
     std::vector<char> tail(static_cast<size_t>(tail_len));
     if (!read_exact(file, tail.data(), tail.size())) {
-        log_error("Failed to read MD5 trailer region: " + file_path);
+        log_error(std::format("Failed to read MD5 trailer region: {}", file_path));
         return ExitCode::Firmware;
     }
 
@@ -184,7 +180,7 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
     if (best_pos < 0) {
         std::string last32(tail.end() - 32, tail.end());
         if (!is_hex32(last32)) {
-            log_error("Unable to locate a valid MD5 trailer in: " + file_path);
+            log_error(std::format("Unable to locate a valid MD5 trailer in: {}", file_path));
             return ExitCode::Firmware;
         }
         info.has_md5 = true;
@@ -195,7 +191,7 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
 
     std::string md5(tail.data() + best_pos, 32);
     if (!is_hex32(md5)) {
-        log_error("Detected an invalid MD5 trailer in: " + file_path);
+        log_error(std::format("Detected an invalid MD5 trailer in: {}", file_path));
         return ExitCode::Firmware;
     }
 
@@ -209,7 +205,7 @@ auto detect_tar_md5_info(const std::string& file_path, TarMd5Info& info) -> Exit
 
     const uint64_t trailer_start = (file_size - tail_len) + static_cast<uint64_t>(line_start);
     if (trailer_start >= file_size) {
-        log_error("Invalid MD5 trailer position in: " + file_path);
+        log_error(std::format("Invalid MD5 trailer position in: {}", file_path));
         return ExitCode::Firmware;
     }
 
@@ -225,13 +221,13 @@ auto verify_tar_md5(const std::string& file_path, const TarMd5Info& info) -> Exi
     }
 
     if (info.content_end == 0) {
-        log_error("Invalid MD5 content size (0): " + file_path);
+        log_error(std::format("Invalid MD5 content size (0): {}", file_path));
         return ExitCode::Firmware;
     }
 
     std::ifstream file(file_path, std::ios::binary);
     if (!file) {
-        log_error("Could not open file for MD5 verification: " + file_path);
+        log_error(std::format("Could not open file for MD5 verification: {}", file_path));
         return ExitCode::Firmware;
     }
 
@@ -245,7 +241,7 @@ auto verify_tar_md5(const std::string& file_path, const TarMd5Info& info) -> Exi
     while (remaining > 0) {
         const size_t to_read = static_cast<size_t>(std::min<uint64_t>(remaining, buf.size()));
         if (!read_exact(file, buf.data(), to_read)) {
-            log_error("Short read during MD5 verification: " + file_path);
+            log_error(std::format("Short read during MD5 verification: {}", file_path));
             return ExitCode::Firmware;
         }
         hash.Update(reinterpret_cast<const unsigned char*>(buf.data()), to_read);
@@ -262,7 +258,7 @@ auto verify_tar_md5(const std::string& file_path, const TarMd5Info& info) -> Exi
 
     const std::string calc_lower = to_lower_copy(calculated);
     if (calc_lower != info.expected_md5) {
-        log_error("MD5 verification failed. Expected: " + info.expected_md5 + " | Calculated: " + calc_lower);
+        log_error(std::format("MD5 verification failed. Expected: {} | Calculated: {}", info.expected_md5, calc_lower));
         return ExitCode::Firmware;
     }
 
@@ -271,12 +267,7 @@ auto verify_tar_md5(const std::string& file_path, const TarMd5Info& info) -> Exi
 }
 
 auto is_all_zeros_block(const char* header) -> bool {
-    for (int i = 0; i < 512; ++i) {
-        if (header[i] != 0) {
-            return false;
-        }
-    }
-    return true;
+    return std::ranges::all_of(std::span(header, 512), [](char c) { return c == 0; });
 }
 
 auto tar_header_checksum_valid(const char* header) -> bool {
@@ -515,7 +506,7 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
         }
 
         if (!frame_ended) {
-            log_error("LZ4 scan decompression error for " + filename + ": " + std::string(LZ4F_getErrorName(scan_err)));
+            log_error(std::format("LZ4 scan decompression error for {}: {}", filename, LZ4F_getErrorName(scan_err)));
             LZ4F_freeDecompressionContext(scan_ctx);
             return false;
         }
@@ -538,11 +529,11 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
         file.clear();
         file.seekg(scan_start);
         if (!file) {
-            log_error("Failed to rewind file after LZ4 size scan for " + filename);
+            log_error(std::format("Failed to rewind file after LZ4 size scan for {}", filename));
             return false;
         }
         remaining_compressed = compressed_size;
-        log_verbose("LZ4 size scan complete for " + filename + ": " + std::to_string(uncompressed_size) + " bytes");
+        log_verbose(std::format("LZ4 size scan complete for {}: {} bytes", filename, uncompressed_size));
     }
 
     if (do_flash) {
@@ -576,18 +567,18 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
             size_t src_consumed = src_size;
             err = LZ4F_decompress(dctx, out_buf.data(), &dst_size, in_buf.data() + src_offset, &src_consumed, nullptr);
             if (LZ4F_isError(err) != 0U) {
-                log_error("LZ4 decompression error for " + filename + ": " + std::string(LZ4F_getErrorName(err)));
+                log_error(std::format("LZ4 decompression error for {}: {}", filename, LZ4F_getErrorName(err)));
                 return false;
             }
             if (src_consumed == 0 && dst_size == 0 && err != 0) {
                 if (remaining_compressed == 0) {
-                    log_error("LZ4 decompression made no progress for " + filename);
+                    log_error(std::format("LZ4 decompression made no progress for {}", filename));
                     return false;
                 }
 
                 if (src_offset != 0 && src_size > 0) {
                     if (src_offset + src_size > in_buf_size) {
-                        log_error("LZ4 buffer overflow for " + filename);
+                        log_error(std::format("LZ4 buffer overflow for {}", filename));
                         return false;
                     }
                     std::memmove(in_buf.data(), in_buf.data() + src_offset, src_size);
@@ -597,7 +588,7 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
                 const size_t space = in_buf_size - src_size;
                 const auto to_read = static_cast<size_t>(std::min<uint64_t>(space, remaining_compressed));
                 if (to_read == 0) {
-                    log_error("LZ4 decompression made no progress for " + filename);
+                    log_error(std::format("LZ4 decompression made no progress for {}", filename));
                     return false;
                 }
 
@@ -623,7 +614,8 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
                     const int percent = static_cast<int>(
                         (static_cast<double>(total_uncompressed) / static_cast<double>(uncompressed_size)) * 100.0);
                     if (percent != last_percent) {
-                        std::cout << "\r[Flash] " << filename << ": " << percent << "%" << std::flush;
+                        std::print("\r[Flash] {}: {}%", filename, percent);
+                        std::cout.flush();
                         last_percent = percent;
                     }
                 }
@@ -653,14 +645,13 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
     }
 
     if (show_progress && uncompressed_size > 0) {
-        std::cout << "\r[Flash] " << filename << ": 100%" << '\n';
+        std::println("\r[Flash] {}: 100%", filename);
     } else if (show_progress) {
-        std::cout << '\n';
+        std::println("");
     }
 
     if (uncompressed_size != 0 && total_uncompressed != uncompressed_size) {
-        log_error("Decompressed size mismatch for " + filename + ": expected " + std::to_string(uncompressed_size) +
-                  ", got " + std::to_string(total_uncompressed));
+        log_error(std::format("Decompressed size mismatch for {}: expected {}, got {}", filename, uncompressed_size, total_uncompressed));
         return false;
     }
 
@@ -669,7 +660,7 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
 
 auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const PitTable& pit_table, bool do_flash,
                       bool allow_unknown) -> ExitCode {
-    log_info("Processing archive: " + tar_path);
+    log_info(std::format("Processing archive: {}", tar_path));
 
     TarMd5Info md5_info;
     ExitCode ec = detect_tar_md5_info(tar_path, md5_info);
@@ -683,14 +674,14 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
 
     std::ifstream file(tar_path, std::ios::binary);
     if (!file) {
-        log_error("Could not open archive: " + tar_path);
+        log_error(std::format("Could not open archive: {}", tar_path));
         return ExitCode::Firmware;
     }
 
     file.seekg(0, std::ios::end);
     const std::streampos sp = file.tellg();
     if (sp < 0) {
-        log_error("Failed to determine archive size: " + tar_path);
+        log_error(std::format("Failed to determine archive size: {}", tar_path));
         return ExitCode::Firmware;
     }
     const auto file_size = static_cast<uint64_t>(sp);
@@ -698,7 +689,7 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
 
     const uint64_t content_end = md5_info.has_md5 ? md5_info.content_end : file_size;
     if (content_end < 512) {
-        log_error("Archive content is too small: " + tar_path);
+        log_error(std::format("Archive content is too small: {}", tar_path));
         return ExitCode::Firmware;
     }
 
@@ -723,7 +714,7 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
     while (true) {
         const std::streampos hpos = file.tellg();
         if (hpos < 0) {
-            log_error("Archive read error: " + tar_path);
+            log_error(std::format("Archive read error: {}", tar_path));
             return ExitCode::Firmware;
         }
         const auto pos = static_cast<uint64_t>(hpos);
@@ -732,7 +723,7 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
         }
 
         if (!read_exact(file, header, 512)) {
-            log_error("Failed to read TAR header (truncated archive): " + tar_path);
+            log_error(std::format("Failed to read TAR header (truncated archive): {}", tar_path));
             return ExitCode::Firmware;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,68 +15,69 @@
  */
 
 #include <iostream>
+#include <print>
 #include <string>
 #include <vector>
 #include <filesystem>
 #include "odin4/odin4.h"
 
 static void print_usage() {
-    std::cout << "Usage: odin4 [options]" << '\n';
-    std::cout << "Samsung firmware flashing tool for Linux. Version: " << odin4_get_version() << '\n';
-    std::cout << '\n';
-    std::cout << "Options:" << '\n';
-    std::cout << "  -h                  Show this help message" << '\n';
-    std::cout << "  -v                  Show version" << '\n';
-    std::cout << "  -w                  Show license" << '\n';
-    std::cout << "  -l                  List detected Download Mode devices" << '\n';
-    std::cout << "  -d <path>            Select a specific USB device path (e.g. /dev/bus/usb/001/002)" << '\n';
-    std::cout << "  -b <file>            Bootloader archive (.tar or .tar.md5)" << '\n';
-    std::cout << "  -a <file>            AP archive (.tar or .tar.md5)" << '\n';
-    std::cout << "  -c <file>            CP archive (.tar or .tar.md5)" << '\n';
-    std::cout << "  -s <file>            CSC archive (.tar or .tar.md5)" << '\n';
-    std::cout << "  -u <file>            UMS archive (.tar or .tar.md5)" << '\n';
-    std::cout << "  --check-only         Validate PIT + archives and exit without flashing" << '\n';
-    std::cout << "  --allow-unknown      Allow archive entries without a PIT match (disabled by default)" << '\n';
-    std::cout << "  --reboot             Reboot device after flashing" << '\n';
-    std::cout << "  --redownload         Reboot into download mode if supported" << '\n';
-    std::cout << '\n';
-    std::cout << "Logging:" << '\n';
-    std::cout << "  --quiet              Only print errors" << '\n';
-    std::cout << "  --verbose            More detailed logs" << '\n';
-    std::cout << "  --debug              Debug logs (includes USB packet hexdumps)" << '\n';
-    std::cout << '\n';
-    std::cout << "USB selection overrides (optional):" << '\n';
-    std::cout << "  --vid <hex>          Override USB vendor ID (hex, e.g. 04e8)" << '\n';
-    std::cout << "  --pid <hex>          Override USB product ID (hex)" << '\n';
-    std::cout << "  --usb-interface <n>  Force a specific USB interface number" << '\n';
-    std::cout << '\n';
-    std::cout << "Linux permissions:" << '\n';
-    std::cout << "  If you get LIBUSB_ERROR_ACCESS, install the provided udev rule:" << '\n';
-    std::cout << "    udev/60-odin4.rules -> /etc/udev/rules.d/60-odin4.rules" << '\n';
+    std::println("Usage: odin4 [options]");
+    std::println("Samsung firmware flashing tool for Linux. Version: {}", odin4_get_version());
+    std::println("");
+    std::println("Options:");
+    std::println("  -h                  Show this help message");
+    std::println("  -v                  Show version");
+    std::println("  -w                  Show license");
+    std::println("  -l                  List detected Download Mode devices");
+    std::println("  -d <path>            Select a specific USB device path (e.g. /dev/bus/usb/001/002)");
+    std::println("  -b <file>            Bootloader archive (.tar or .tar.md5)");
+    std::println("  -a <file>            AP archive (.tar or .tar.md5)");
+    std::println("  -c <file>            CP archive (.tar or .tar.md5)");
+    std::println("  -s <file>            CSC archive (.tar or .tar.md5)");
+    std::println("  -u <file>            UMS archive (.tar or .tar.md5)");
+    std::println("  --check-only         Validate PIT + archives and exit without flashing");
+    std::println("  --allow-unknown      Allow archive entries without a PIT match (disabled by default)");
+    std::println("  --reboot             Reboot device after flashing");
+    std::println("  --redownload         Reboot into download mode if supported");
+    std::println("");
+    std::println("Logging:");
+    std::println("  --quiet              Only print errors");
+    std::println("  --verbose            More detailed logs");
+    std::println("  --debug              Debug logs (includes USB packet hexdumps)");
+    std::println("");
+    std::println("USB selection overrides (optional):");
+    std::println("  --vid <hex>          Override USB vendor ID (hex, e.g. 04e8)");
+    std::println("  --pid <hex>          Override USB product ID (hex)");
+    std::println("  --usb-interface <n>  Force a specific USB interface number");
+    std::println("");
+    std::println("Linux permissions:");
+    std::println("  If you get LIBUSB_ERROR_ACCESS, install the provided udev rule:");
+    std::println("    udev/60-odin4.rules -> /etc/udev/rules.d/60-odin4.rules");
 }
 
 static void print_version() {
-    std::cout << "odin4 version " << odin4_get_version() << '\n';
+    std::println("odin4 version {}", odin4_get_version());
 }
 
 static void print_license() {
-    std::cout << "odin4 — Open Odin Reimplementation" << '\n';
-    std::cout << '\n';
-    std::cout << "Copyright (c) 2026 Llucs" << '\n';
-    std::cout << '\n';
-    std::cout << "Licensed under the Apache License, Version 2.0 (the \"License\");" << '\n';
-    std::cout << "you may not use this software except in compliance with the License." << '\n';
-    std::cout << "You may obtain a copy of the License at:" << '\n';
-    std::cout << '\n';
-    std::cout << "  http://www.apache.org/licenses/LICENSE-2.0" << '\n';
-    std::cout << '\n';
-    std::cout << "This software is provided \"AS IS\", WITHOUT WARRANTIES OR CONDITIONS" << '\n';
-    std::cout << "OF ANY KIND, either express or implied." << '\n';
+    std::println("odin4 — Open Odin Reimplementation");
+    std::println("");
+    std::println("Copyright (c) 2026 Llucs");
+    std::println("");
+    std::println("Licensed under the Apache License, Version 2.0 (the \"License\");");
+    std::println("you may not use this software except in compliance with the License.");
+    std::println("You may obtain a copy of the License at:");
+    std::println("");
+    std::println("  http://www.apache.org/licenses/LICENSE-2.0");
+    std::println("");
+    std::println("This software is provided \"AS IS\", WITHOUT WARRANTIES OR CONDITIONS");
+    std::println("OF ANY KIND, either express or implied.");
 }
 
 static auto parse_hex_u16(const std::string& s, uint16_t& out) -> bool {
     std::string v = s;
-    if (v.rfind("0x", 0) == 0 || v.rfind("0X", 0) == 0) {
+    if (v.starts_with("0x") || v.starts_with("0X")) {
         v = v.substr(2);
     }
     if (v.empty() || v.size() > 4) {
@@ -192,7 +193,7 @@ auto main(int argc, char** argv) -> int {
         if (arg == "--vid") {
             uint16_t v = 0;
             if (!take_value_u16hex(v)) {
-                std::cerr << "Error: --vid requires a hex value" << '\n';
+                std::println(std::cerr, "Error: --vid requires a hex value");
                 return 1;
             }
             cfg.has_vid = true;
@@ -202,7 +203,7 @@ auto main(int argc, char** argv) -> int {
         if (arg == "--pid") {
             uint16_t p = 0;
             if (!take_value_u16hex(p)) {
-                std::cerr << "Error: --pid requires a hex value" << '\n';
+                std::println(std::cerr, "Error: --pid requires a hex value");
                 return 1;
             }
             cfg.has_pid = true;
@@ -212,7 +213,7 @@ auto main(int argc, char** argv) -> int {
         if (arg == "--usb-interface") {
             int n = 0;
             if (!take_value_int(n) || n < 0 || n > 255) {
-                std::cerr << "Error: --usb-interface requires an integer in the range 0..255" << '\n';
+                std::println(std::cerr, "Error: --usb-interface requires an integer in the range 0..255");
                 return 1;
             }
             cfg.has_usb_interface = true;
@@ -224,10 +225,10 @@ auto main(int argc, char** argv) -> int {
             odin4_init(cfg);
             const std::vector<std::string> devices = odin4_list_devices(cfg);
             if (devices.empty()) {
-                std::cout << "No devices detected in Download Mode." << '\n';
+                std::println("No devices detected in Download Mode.");
             } else {
                 for (const auto& path : devices) {
-                    std::cout << path << '\n';
+                    std::println("{}", path);
                 }
             }
             return 0;
@@ -236,7 +237,7 @@ auto main(int argc, char** argv) -> int {
         if (arg == "-b" || arg == "-a" || arg == "-c" || arg == "-s" || arg == "-u" || arg == "-d") {
             std::string value;
             if (!take_value(value)) {
-                std::cerr << "Error: Option requires an argument: " << arg << '\n';
+                std::println(std::cerr, "Error: Option requires an argument: {}", arg);
                 return 1;
             }
             if (arg == "-b") {
@@ -255,8 +256,8 @@ auto main(int argc, char** argv) -> int {
             continue;
         }
 
-        if (!arg.empty() && arg[0] == '-') {
-            std::cerr << "Error: Unknown option: " << arg << '\n';
+        if (!arg.empty() && arg.starts_with('-')) {
+            std::println(std::cerr, "Error: Unknown option: {}", arg);
             return 1;
         }
     }
@@ -264,7 +265,7 @@ auto main(int argc, char** argv) -> int {
     odin4_init(cfg);
 
     if (cfg.dry_run && !has_any_firmware_files(cfg)) {
-        std::cerr << "Error: --check-only requires at least one firmware archive (-b/-a/-c/-s/-u)" << '\n';
+        std::println(std::cerr, "Error: --check-only requires at least one firmware archive (-b/-a/-c/-s/-u)");
         return 1;
     }
 
@@ -275,7 +276,7 @@ auto main(int argc, char** argv) -> int {
 
     for (const auto& path : {cfg.bootloader, cfg.ap, cfg.cp, cfg.csc, cfg.ums}) {
         if (!path.empty() && !std::filesystem::exists(path)) {
-            std::cerr << "Error: Firmware file not found: " << path << '\n';
+            std::println(std::cerr, "Error: Firmware file not found: {}", path);
             return 5; // Firmware error
         }
     }

--- a/src/odin4.cpp
+++ b/src/odin4.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <algorithm>
 #include <ranges>
+#include <format>
 #include <filesystem>
 
 #define ODIN4_VERSION "6.0.0-aefb1e5"

--- a/src/odin4.cpp
+++ b/src/odin4.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <ranges>
 #include <filesystem>
 
 #define ODIN4_VERSION "6.0.0-aefb1e5"
@@ -87,15 +88,13 @@ static auto verify_firmware_compatibility(const OdinConfig& cfg, const std::stri
     }
 
     std::string dt = device_type;
-    dt.erase(
-        std::remove_if(dt.begin(), dt.end(),
-                       [](unsigned char c) { return (std::isspace(c) != 0) || c == '\\' || c == '/' || c == '-'; }),
-        dt.end());
+    std::erase_if(dt, [](unsigned char c) {
+        return (std::isspace(c) != 0) || c == '\\' || c == '/' || c == '-';
+    });
 
-    std::transform(dt.begin(), dt.end(), dt.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    std::ranges::transform(dt, dt.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
 
-    if (dt.rfind("SM", 0) == 0) {
+    if (dt.starts_with("SM")) {
         dt = dt.substr(2);
     }
 
@@ -119,8 +118,8 @@ static auto verify_firmware_compatibility(const OdinConfig& cfg, const std::stri
             continue;
         }
         if (!file_matches(p)) {
-            log_error("Firmware file name does not appear to match device type: " +
-                      std::filesystem::path(p).filename().string() + " vs " + device_type);
+            log_error(std::format("Firmware file name does not appear to match device type: {} vs {}",
+                                  std::filesystem::path(p).filename().string(), device_type));
             return false;
         }
     }
@@ -162,7 +161,7 @@ static auto run_for_device(const OdinConfig& cfg) -> OdinExitCode {
 
     const std::string device_type = usb.get_device_type();
     if (!device_type.empty()) {
-        log_info("Device type: " + device_type);
+        log_info(std::format("Device type: {}", device_type));
     }
 
     if (has_any_firmware_files(cfg)) {
@@ -182,7 +181,7 @@ static auto run_for_device(const OdinConfig& cfg) -> OdinExitCode {
         usb.end_session();
         return OdinExitCode::Pit;
     }
-    log_info("PIT received with " + std::to_string(pit.entries.size()) + " entries.");
+    log_info(std::format("PIT received with {} entries.", pit.entries.size()));
 
     if (has_any_firmware_files(cfg)) {
         const std::vector<std::pair<std::string, std::string>> archives = {
@@ -264,13 +263,13 @@ auto odin4_run(const OdinConfig& cfg) -> OdinExitCode {
         if (devices.size() > 1) {
             log_error("Multiple compatible devices detected in Download Mode. Use -d to select one device.");
             for (const auto& dev_path : devices) {
-                log_info("Detected device: " + dev_path);
+                log_info(std::format("Detected device: {}", dev_path));
             }
             return OdinExitCode::Usb;
         }
         OdinConfig one = cfg;
         one.device_path = devices.front();
-        log_info("Using device: " + one.device_path);
+        log_info(std::format("Using device: {}", one.device_path));
         return run_for_device(one);
     }
 

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -23,9 +23,11 @@
 #include <cstring>
 #include <vector>
 #include <algorithm>
+#include <ranges>
 #include <cctype>
 #include <unordered_set>
 #include <limits>
+#include <format>
 #include <mutex>
 #include <cstdlib>
 
@@ -150,7 +152,7 @@ auto UsbDevice::bulk_read_once(void* data, size_t size, int* actual_length, int 
         if (err == LIBUSB_ERROR_PIPE) {
             (void) libusb_clear_halt(handle, endpoint_in);
         }
-        log_error("USB bulk read failed", err);
+        log_error(std::format("USB bulk read failed (error: {})", err));
         if (attempt < USB_RETRY_COUNT - 1) {
             std::this_thread::sleep_for(std::chrono::milliseconds(retry_backoff_ms(attempt)));
         }
@@ -166,12 +168,7 @@ static auto usb_path_for_device(libusb_device* dev) -> std::string {
 }
 
 static auto is_known_download_pid(uint16_t pid) -> bool {
-    for (uint16_t known : SAMSUNG_DOWNLOAD_PIDS) {
-        if (pid == known) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(SAMSUNG_DOWNLOAD_PIDS, [pid](uint16_t known) { return pid == known; });
 }
 
 struct InterfaceCandidate {
@@ -276,7 +273,7 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     if (!ensure_libusb_initialized()) {
         last_open_error = UsbOpenError::Other;
         last_open_libusb_err = LIBUSB_ERROR_OTHER;
-        log_error("Failed to enumerate USB devices", LIBUSB_ERROR_OTHER);
+        log_error(std::format("Failed to enumerate USB devices (error: {})", LIBUSB_ERROR_OTHER));
         return false;
     }
 
@@ -284,7 +281,7 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     if (cnt < 0) {
         last_open_error = UsbOpenError::Other;
         last_open_libusb_err = static_cast<int>(cnt);
-        log_error("Failed to enumerate USB devices", static_cast<int>(cnt));
+        log_error(std::format("Failed to enumerate USB devices (error: {})", static_cast<int>(cnt)));
         return false;
     }
 
@@ -529,12 +526,12 @@ auto UsbDevice::handshake() -> bool {
         return false;
     }
     if (le16toh(rsp.header.packet_type) != THOR_PACKET_RESPONSE) {
-        log_error("Handshake failed with unexpected packet type: " + std::to_string(le16toh(rsp.header.packet_type)));
+        log_error(std::format("Handshake failed with unexpected packet type: {}", le16toh(rsp.header.packet_type)));
         return false;
     }
     uint32_t code = le32_to_h(rsp.response_code);
     if (code != 0) {
-        log_error("Handshake failed with response code: " + std::to_string(code));
+        log_error(std::format("Handshake failed with response code: {}", code));
         return false;
     }
     return true;
@@ -563,8 +560,7 @@ auto UsbDevice::request_device_type() -> bool {
     }
 
     if (le16toh(response.header.packet_type) != THOR_PACKET_DEVICE_TYPE) {
-        log_error("Device type request failed. Unexpected packet type: " +
-                  std::to_string(le16toh(response.header.packet_type)));
+        log_error(std::format("Device type request failed. Unexpected packet type: {}", le16toh(response.header.packet_type)));
         return false;
     }
     // Copy the device type string from the response. The char array is
@@ -577,7 +573,7 @@ auto UsbDevice::request_device_type() -> bool {
         }
         device_type_str.push_back(c);
     }
-    log_info("Device type received: " + device_type_str);
+    log_info(std::format("Device type received: {}", device_type_str));
     return true;
 }
 
@@ -673,13 +669,13 @@ auto UsbDevice::begin_session() -> bool {
     }
 
     if (actual_length < static_cast<int>(sizeof(ThorResponsePacket))) {
-        log_error("Session begin failed: short response (" + std::to_string(actual_length) + " bytes)");
+        log_error(std::format("Session begin failed: short response ({} bytes)", actual_length));
         return false;
     }
 
     uint32_t code = le32_to_h(response.response_code);
     if (le16toh(response.header.packet_type) != THOR_PACKET_RESPONSE || code != 0) {
-        log_error("Session begin failed. Response code: " + std::to_string(code));
+        log_error(std::format("Session begin failed. Response code: {}", code));
         return false;
     }
     log_info("Session started successfully.");
@@ -708,13 +704,13 @@ auto UsbDevice::end_session() -> bool {
     }
 
     if (actual_length < static_cast<int>(sizeof(ThorResponsePacket))) {
-        log_error("Session end failed: short response (" + std::to_string(actual_length) + " bytes)");
+        log_error(std::format("Session end failed: short response ({} bytes)", actual_length));
         return false;
     }
 
     uint32_t code = le32_to_h(response.response_code);
     if (le16toh(response.header.packet_type) != THOR_PACKET_RESPONSE || code != 0) {
-        log_error("Session end failed. Response code: " + std::to_string(code));
+        log_error(std::format("Session end failed. Response code: {}", code));
         return false;
     }
     log_info("Session ended successfully.");
@@ -723,7 +719,7 @@ auto UsbDevice::end_session() -> bool {
 
 static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char>& pit_data) -> bool {
     if (pit_data.size() < 28) {
-        log_error("PIT data too small: " + std::to_string(pit_data.size()));
+        log_error(std::format("PIT data too small: {}", pit_data.size()));
         return false;
     }
 
@@ -748,7 +744,7 @@ static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char
 
     pit_table.entry_count = read_u32(4);
     if (pit_table.entry_count == 0 || pit_table.entry_count > 512) {
-        log_error("Invalid PIT entry count: " + std::to_string(pit_table.entry_count));
+        log_error(std::format("Invalid PIT entry count: {}", pit_table.entry_count));
         return false;
     }
 
@@ -765,7 +761,7 @@ static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char
     const size_t entry_size = 132;
     const size_t required = pit_table.header_size + static_cast<size_t>(pit_table.entry_count) * entry_size;
     if (pit_data.size() < required) {
-        log_error("PIT truncated: expected at least " + std::to_string(required) + " bytes");
+        log_error(std::format("PIT truncated: expected at least {} bytes", required));
         return false;
     }
 
@@ -818,24 +814,24 @@ static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char
         const std::string file_name = extract_field(e.file_name, 32);
 
         if (part_name.empty()) {
-            log_error("PIT entry " + std::to_string(i) + " has an empty partition name");
+            log_error(std::format("PIT entry {} has an empty partition name", i));
             return false;
         }
         if (!is_valid_pit_string(part_name)) {
-            log_error("PIT entry " + std::to_string(i) + " has an invalid partition name: '" + part_name + "'");
+            log_error(std::format("PIT entry {} has an invalid partition name: '{}'", i, part_name));
             return false;
         }
         if (!file_name.empty() && !is_valid_pit_string(file_name)) {
-            log_error("PIT entry " + std::to_string(i) + " has an invalid file name: '" + file_name + "'");
+            log_error(std::format("PIT entry {} has an invalid file name: '{}'", i, file_name));
             return false;
         }
 
         if (e.identifier == 0) {
-            log_error("PIT entry " + std::to_string(i) + " has an invalid identifier (0)");
+            log_error(std::format("PIT entry {} has an invalid identifier (0)", i));
             return false;
         }
         if (!seen_identifiers.insert(e.identifier).second) {
-            log_error("PIT contains duplicate partition identifier: " + std::to_string(e.identifier));
+            log_error(std::format("PIT contains duplicate partition identifier: {}", e.identifier));
             return false;
         }
 
@@ -844,7 +840,7 @@ static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char
             const auto b = static_cast<uint64_t>(e.block_count);
             const uint64_t prod = a * b;
             if (a != 0 && prod / a != b) {
-                log_error("PIT entry " + std::to_string(i) + " has an overflow in block size/count");
+                log_error(std::format("PIT entry {} has an overflow in block size/count", i));
                 return false;
             }
         }
@@ -853,7 +849,7 @@ static auto parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char
         pit_table.entries.push_back(e);
     }
 
-    log_info("Received PIT entries: " + std::to_string(pit_table.entry_count));
+    log_info(std::format("Received PIT entries: {}", pit_table.entry_count));
     return true;
 }
 
@@ -891,19 +887,18 @@ auto UsbDevice::receive_pit_table(PitTable& pit_table) -> bool {
     }
 
     if (actual_length < static_cast<int>(sizeof(ThorPitFilePacket))) {
-        log_error("Short PIT size packet (" + std::to_string(actual_length) + " bytes)");
+        log_error(std::format("Short PIT size packet ({} bytes)", actual_length));
         return false;
     }
 
     if (le16toh(pit_size_pkt.header.packet_type) != THOR_PACKET_PIT_FILE) {
-        log_error("Unexpected packet type while reading PIT size: " +
-                  std::to_string(le16toh(pit_size_pkt.header.packet_type)));
+        log_error(std::format("Unexpected packet type while reading PIT size: {}", le16toh(pit_size_pkt.header.packet_type)));
         return false;
     }
 
     uint32_t pit_data_size = le32_to_h(pit_size_pkt.pit_file_size);
     if (pit_data_size < 28 || pit_data_size > 1048576) {
-        log_error("Invalid PIT size: " + std::to_string(pit_data_size));
+        log_error(std::format("Invalid PIT size: {}", pit_data_size));
         return false;
     }
 
@@ -936,7 +931,7 @@ auto UsbDevice::send_file_part_chunk(const void* data, size_t size, uint32_t chu
     }
 
     if (actual_length < static_cast<int>(sizeof(ThorResponsePacket))) {
-        log_error("File part control failed: short response (" + std::to_string(actual_length) + " bytes)");
+        log_error(std::format("File part control failed: short response ({} bytes)", actual_length));
         return false;
     }
     uint32_t code = le32toh(response.response_code);
@@ -959,12 +954,12 @@ auto UsbDevice::send_file_part_chunk(const void* data, size_t size, uint32_t chu
         return false;
     }
     if (post_len < static_cast<int>(sizeof(ThorResponsePacket))) {
-        log_error("Post-data ACK was short (" + std::to_string(post_len) + " bytes)");
+        log_error(std::format("Post-data ACK was short ({} bytes)", post_len));
         return false;
     }
     uint32_t post_code = le32toh(post.response_code);
     if (le16toh(post.header.packet_type) != THOR_PACKET_RESPONSE || post_code != 0) {
-        log_error("File part data ACK reported failure. Code: " + std::to_string(post_code));
+        log_error(std::format("File part data ACK reported failure. Code: {}", post_code));
         return false;
     }
 
@@ -1005,7 +1000,7 @@ auto UsbDevice::send_file_part_header(uint64_t total_size) -> bool {
     }
 
     if (le16toh(response.header.packet_type) != THOR_PACKET_RESPONSE || code != 0) {
-        log_error("Unexpected response sending file part size. Code: " + std::to_string(code));
+        log_error(std::format("Unexpected response sending file part size. Code: {}", code));
         return false;
     }
     return true;
@@ -1017,7 +1012,7 @@ auto UsbDevice::end_file_transfer(uint32_t partition_id) -> bool {
         // Keep this as a no-op to avoid sending THOR packets in legacy mode.
         return true;
     }
-    log_info("Finalizing file transfer for partition ID: " + std::to_string(partition_id));
+    log_info(std::format("Finalizing file transfer for partition ID: {}", partition_id));
     ThorEndFileTransferPacket pkt = {};
     pkt.header.packet_size = h_to_le32(sizeof(ThorEndFileTransferPacket));
     pkt.header.packet_type = h_to_le16(THOR_PACKET_END_FILE_TRANSFER);
@@ -1035,12 +1030,12 @@ auto UsbDevice::end_file_transfer(uint32_t partition_id) -> bool {
     }
 
     if (actual_length < static_cast<int>(sizeof(ThorResponsePacket))) {
-        log_error("File transfer finalization failed: short response (" + std::to_string(actual_length) + " bytes)");
+        log_error(std::format("File transfer finalization failed: short response ({} bytes)", actual_length));
         return false;
     }
     uint32_t code = le32_to_h(response.response_code);
     if (le16toh(response.header.packet_type) != THOR_PACKET_RESPONSE || code != 0) {
-        log_error("File transfer finalization failed. Code: " + std::to_string(code));
+        log_error(std::format("File transfer finalization failed. Code: {}", code));
         return false;
     }
     log_info("File transfer finalized.");
@@ -1058,7 +1053,7 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
         return true;
     }
 
-    log_info("Sending control command: " + std::to_string(control_type));
+    log_info(std::format("Sending control command: {}", control_type));
     ThorControlPacket pkt = {};
     pkt.header.packet_size = h_to_le32(sizeof(ThorControlPacket));
     pkt.header.packet_type = h_to_le16(THOR_PACKET_CONTROL);
@@ -1081,7 +1076,7 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
     }
 
     if (le16toh(response.header.packet_type) != THOR_PACKET_RESPONSE || code != 0) {
-        log_error("Control command failed. Code: " + std::to_string(code));
+        log_error(std::format("Control command failed. Code: {}", code));
         return false;
     }
     log_info("Control command successful.");
@@ -1112,7 +1107,7 @@ auto UsbDevice::odin_command(uint32_t cmd, uint32_t subcmd, const void* payload,
         return false;
     }
     if (read_len != 8) {
-        log_error("Odin response size mismatch: " + std::to_string(read_len));
+        log_error(std::format("Odin response size mismatch: {}", read_len));
         return false;
     }
     return true;
@@ -1161,12 +1156,12 @@ auto UsbDevice::odin_fail_check(const std::vector<unsigned char>& rsp, const std
         // Some bootloaders report intermediate/progress states using 0xFF + a negative code.
         // Treat those as non-fatal when explicitly allowed.
         if (code >= -7 && code <= -2) {
-            log_info(context + " progress code " + std::to_string(code) + suffix);
+            log_info(std::format("{} progress code {}{}", context, code, suffix));
             return true;
         }
     }
 
-    log_error(context + " failed with code " + std::to_string(code) + suffix);
+    log_error(std::format("{} failed with code {}{}", context, code, suffix));
     return false;
 }
 


### PR DESCRIPTION
This PR modernizes the project to C++23 standards based on the migration analysis report.

Key changes:
- Updated CMakeLists.txt to C++23.
- Replaced `std::cout`/`std::cerr` with `std::print`/`std::println` for better formatting and performance.
- Replaced `std::string::rfind(..., 0)` with `std::string::starts_with` (C++20).
- Replaced `std::string::substr` for suffix checks with `std::string::ends_with` (C++20).
- Replaced manual loops with `std::ranges` algorithms (C++20).
- Used `std::format` for safer and more flexible string formatting (C++20).
- Used `std::erase_if` for more concise collection element removal (C++20).

Credits: Llucs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Comprehensive modernization of internal code across logging system, firmware package handling, USB device communication, and command-line interface components. Updated implementation to leverage contemporary development practices for improved code quality and maintainability. Error reporting and output formatting refined. All existing functionality and user experience remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/48)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->