### PR TITLE
Fix std::format compatibility with libusb_error enum

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -152,7 +152,7 @@ auto UsbDevice::bulk_read_once(void* data, size_t size, int* actual_length, int 
         if (err == LIBUSB_ERROR_PIPE) {
             (void) libusb_clear_halt(handle, endpoint_in);
         }
-        log_error(std::format("USB bulk read failed (error: {})", err));
+        log_error(std::format("USB bulk read failed (error: {})", static_cast<int>(err)));
         if (attempt < USB_RETRY_COUNT - 1) {
             std::this_thread::sleep_for(std::chrono::milliseconds(retry_backoff_ms(attempt)));
         }
@@ -273,7 +273,7 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     if (!ensure_libusb_initialized()) {
         last_open_error = UsbOpenError::Other;
         last_open_libusb_err = LIBUSB_ERROR_OTHER;
-        log_error(std::format("Failed to enumerate USB devices (error: {})", LIBUSB_ERROR_OTHER));
+        log_error(std::format("Failed to enumerate USB devices (error: {})", static_cast<int>(LIBUSB_ERROR_OTHER)));
         return false;
     }
 


### PR DESCRIPTION
## Summary

Fixed a compilation issue in the codebase when building with GCC 14 and C++23.

## Problem

The code was using `std::format` with libusb_error enum values directly (e.g., `LIBUSB_ERROR_OTHER`, `err`), but C++23's `std::formatter` is not specialized for the `libusb_error` enum type from libusb. This caused compilation failures on GCC 14:

```
error: static assertion failed: std::formatter must be specialized for each type being formatted
```

## Solution

Fixed by casting the libusb_error values to `int` before passing to `std::format`, ensuring compatibility with the standard library's formatter requirements.

### Changes made:
1. `src/usb/usb_device.cpp:155` - Cast `err` to `int` in bulk_read_once error message
2. `src/usb/usb_device.cpp:276` - Cast `LIBUSB_ERROR_OTHER` to `int` in device enumeration error message

## Testing

- All 43 existing tests pass
- Built successfully with GCC 14 on Debian trixie

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to error logging formatting for better diagnostic accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/50)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->