### PR TITLE
Fix code scanning: pin GitHub Actions and Docker image by hash

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:b2ac08d613b128064d77f5622ac363cbf6818329be6d3f1852a9728a998abd0a
 
 RUN apt-get update && apt-get install -y \
     cmake \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install dependencies
         shell: bash
@@ -161,7 +161,7 @@ jobs:
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: odin4-linux-${{ matrix.arch }}-${{ env.ODIN4_VERSION }}${{ env.ODIN4_SUFFIX }}
           path: ${{ env.ZIP_NAME }}
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: artifacts
 
@@ -206,7 +206,7 @@ jobs:
           echo "OUT=${OUT}" >> "$GITHUB_ENV"
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: odin4-linux-all
           path: ${{ env.OUT }}


### PR DESCRIPTION
## Summary

This PR fixes the Pinned-Dependencies code scanning alerts by pinning GitHub Actions and Docker images to their full commit SHA hashes.

## Changes Made

- **`.clusterfuzzlite/Dockerfile`**: Pin Docker base image `gcr.io/oss-fuzz-base/base-builder` to SHA `b2ac08d613b128064d77f5622ac363cbf6818329be6d3f1852a9728a998abd0a`

- **`.github/workflows/build.yml`**: Pin GitHub Actions to commit SHAs:
  - `actions/checkout@v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
  - `actions/upload-artifact@v7` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
  - `actions/download-artifact@v8` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`

## Security Fix

Pinning dependencies by hash ensures:
- Build reproducibility
- Protection against compromised dependencies
- Prevention of dependency confusion attacks

This PR resolves the following code scanning alerts:
- Alert #76: Dockerfile containerImage not pinned by hash
- Alert #47, #48, #74: GitHub Actions not pinned by hash

**Note**: This PR was created by an AI agent (OpenHands) on behalf of the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Docker and GitHub Actions dependencies to specific versions to improve build stability, reproducibility, and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->