### PR TITLE
Add ClusterFuzzLite fuzzing infrastructure

- Add .clusterfuzzlite/Dockerfile with build dependencies
- Add .clusterfuzzlite/build.sh for building fuzz targets with sanitizers
- Add src/fuzz_utils.cpp with PIT parsing for fuzzing
- Add include/odin4/fuzz_utils.h header
- Add fuzz test targets: fuzz_pit, fuzz_thor, fuzz_lz4, fuzz_tar
- Update CMakeLists.txt with odin4_fuzz static library

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -3,9 +3,15 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:b2ac08d613b128064d77f5622ac363cbf6
 RUN apt-get update && apt-get install -y \
     cmake \
     ninja-build \
-    clang
+    clang \
+    pkg-config \
+    libusb-1.0-dev \
+    libcrypto++-dev \
+    qt6-base-dev \
+    qt6-widgets-dev \
+    libarchive-dev
 
 COPY . $SRC/odin4
 WORKDIR $SRC/odin4
 
-COPY .clusterfuzzlite/build.sh $SRC/
+COPY .clusterfuzzlite/build.sh $SRC/odin4/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,14 +1,59 @@
 #!/bin/bash
 set -eux
 
+# Install dependencies (for the case when they're not in the base image)
+apt-get update || true
+apt-get install -y --no-install-recommends \
+    cmake \
+    ninja-build \
+    clang \
+    pkg-config \
+    libusb-1.0-dev \
+    libcrypto++-dev \
+    qt6-base-dev \
+    qt6-widgets-dev \
+    libarchive-dev || true
+
 mkdir -p build
 cd build
 
-cmake ..
-make -j$(nproc)
+# Configure with sanitizers enabled
+cmake .. \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS_RELEASE="-O1 -g -fsanitize=address,undefined,fuzzer" \
+    -DCMAKE_CXX_FLAGS_RELEASE="-O1 -g -fsanitize=address,undefined,fuzzer" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined,fuzzer" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined,fuzzer"
+
+# Build core libraries first
+cmake --build . --target lz4_lib odin4_static --parallel
+
+# Build fuzz targets
+$CXX $CXXFLAGS \
+    -std=c++23 \
+    -I../include -I../lib \
+    ../tests/fuzz_pit.cpp \
+    -L. -lodin4_static -llz4_lib \
+    -o $OUT/fuzz_pit
 
 $CXX $CXXFLAGS \
     -std=c++23 \
-    ../tests/fuzz_pit.cpp \
-    -fsanitize=fuzzer \
-    -o $OUT/fuzz_pit
+    -I../include -I../lib \
+    ../tests/fuzz_thor.cpp \
+    -L. -lodin4_static -llz4_lib \
+    -o $OUT/fuzz_thor
+
+$CXX $CXXFLAGS \
+    -std=c++23 \
+    -I../include -I../lib \
+    ../tests/fuzz_lz4.cpp \
+    -L. -llz4_lib \
+    -o $OUT/fuzz_lz4
+
+$CXX $CXXFLAGS \
+    -std=c++23 \
+    -I../include -I../lib \
+    ../tests/fuzz_tar.cpp \
+    -L. -lodin4_static -llz4_lib \
+    -o $OUT/fuzz_tar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,22 @@ if(ODIN4_BUILD_TESTS)
     list(APPEND ODIN4_ALL_TARGETS odin4_tests)
 endif()
 
+# Fuzz targets are built in .clusterfuzzlite/build.sh
+# The odin4_fuzz library provides PIT parsing for fuzzing
+
+set(ODIN4_FUZZ_SOURCES
+    src/fuzz_utils.cpp
+    lib/lz4/lz4.c
+    lib/lz4/lz4hc.c
+    lib/lz4/lz4frame.c
+    lib/lz4/xxhash.c
+)
+
+add_library(odin4_fuzz STATIC ${ODIN4_FUZZ_SOURCES})
+target_include_directories(odin4_fuzz PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(odin4_fuzz PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(odin4_fuzz PUBLIC ${CMAKE_SOURCE_DIR}/lib)
+
 foreach(target ${ODIN4_ALL_TARGETS})
     target_compile_options(${target} PRIVATE -Wall -Wextra -Wno-cast-function-type)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/include/odin4/fuzz_utils.h
+++ b/include/odin4/fuzz_utils.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Llucs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef ODIN4_FUZZ_UTILS_H
+#define ODIN4_FUZZ_UTILS_H
+
+#include <vector>
+#include <cstdint>
+#include "core/odin_types.h"
+
+// PIT parsing for fuzzing
+auto fuzz_parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char>& pit_data) -> bool;
+
+#endif

--- a/src/fuzz_utils.cpp
+++ b/src/fuzz_utils.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Llucs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "odin4/fuzz_utils.h"
+#include "protocol/thor_protocol.h"
+#include <vector>
+#include <cstring>
+#include <unordered_set>
+
+// PIT parsing - extracted from usb_device.cpp for fuzzing
+// This duplicates the core logic to make it accessible without modifications
+auto fuzz_parse_pit_bytes(PitTable& pit_table, const std::vector<unsigned char>& pit_data) -> bool {
+    if (pit_data.size() < 28) {
+        return false;
+    }
+
+    auto read_u32 = [&](size_t off) -> uint32_t {
+        uint32_t v = 0;
+        std::memcpy(&v, pit_data.data() + off, sizeof(v));
+        return le32_to_h(v);
+    };
+    auto read_u16 = [&](size_t off) -> uint16_t {
+        uint16_t v = 0;
+        std::memcpy(&v, pit_data.data() + off, sizeof(v));
+        return static_cast<uint16_t>(le16toh(v));
+    };
+
+    const uint32_t file_id = read_u32(0);
+    if (file_id != 0x12349876) {
+        return false;
+    }
+
+    pit_table.entry_count = read_u32(4);
+    if (pit_table.entry_count == 0 || pit_table.entry_count > 512) {
+        return false;
+    }
+
+    pit_table.unknown1 = read_u32(8);
+    pit_table.unknown2 = read_u32(12);
+    pit_table.unknown3 = read_u16(16);
+    pit_table.unknown4 = read_u16(18);
+    pit_table.unknown5 = read_u16(20);
+    pit_table.unknown6 = read_u16(22);
+    pit_table.unknown7 = read_u16(24);
+    pit_table.unknown8 = read_u16(26);
+
+    pit_table.header_size = 28;
+    const size_t entry_size = 132;
+    const size_t required = pit_table.header_size + static_cast<size_t>(pit_table.entry_count) * entry_size;
+    if (pit_data.size() < required) {
+        return false;
+    }
+
+    pit_table.entries.clear();
+    pit_table.entries.reserve(pit_table.entry_count);
+
+    auto extract_field = [](const char* field, size_t max_len) -> std::string {
+        size_t n = 0;
+        while (n < max_len && field[n] != '\0') {
+            ++n;
+        }
+        std::string s(field, n);
+        while (!s.empty() && (s.back() == ' ' || s.back() == '\t')) {
+            s.pop_back();
+        }
+        return s;
+    };
+
+    std::unordered_set<uint32_t> seen_identifiers;
+
+    for (uint32_t i = 0; i < pit_table.entry_count; ++i) {
+        const size_t off = pit_table.header_size + static_cast<size_t>(i) * entry_size;
+        PitEntry e = {};
+        e.binary_type = read_u32(off + 0);
+        e.device_type = read_u32(off + 4);
+        e.identifier = read_u32(off + 8);
+        e.attributes = read_u32(off + 12);
+        e.update_attributes = read_u32(off + 16);
+        e.block_size_or_offset = read_u32(off + 20);
+        e.block_count = read_u32(off + 24);
+        e.file_offset = read_u32(off + 28);
+        e.file_size = read_u32(off + 32);
+        std::memcpy(e.partition_name, pit_data.data() + off + 36, 32);
+        std::memcpy(e.file_name, pit_data.data() + off + 68, 32);
+        std::memcpy(e.fota_name, pit_data.data() + off + 100, 32);
+
+        const std::string part_name = extract_field(e.partition_name, 32);
+
+        if (part_name.empty()) {
+            return false;
+        }
+        if (e.identifier == 0) {
+            return false;
+        }
+        if (!seen_identifiers.insert(e.identifier).second) {
+            return false;
+        }
+
+        pit_table.entries.push_back(e);
+    }
+
+    return true;
+}

--- a/tests/fuzz_lz4.cpp
+++ b/tests/fuzz_lz4.cpp
@@ -17,16 +17,29 @@
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
-#include <vector>
-#include "core/odin_types.h"
-#include "odin4/fuzz_utils.h"
+#include <lz4frame.h>
+#include "lz4/lz4.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     try {
-        std::vector<unsigned char> pit_data(size);
-        std::memcpy(pit_data.data(), data, size);
-        PitTable pit_table;
-        fuzz_parse_pit_bytes(pit_table, pit_data);
+        // Test LZ4 frame parsing
+        if (size > 0) {
+            fuzz_lz4_decompress(data, size);
+        }
+        
+        // Test raw LZ4 compression decompression (non-frame)
+        if (size > 0 && size < (1 << 20)) {
+            char decompressed[4096];
+            const int decompressed_size = LZ4_decompress_safe(
+                reinterpret_cast<const char*>(data),
+                decompressed,
+                static_cast<int>(size),
+                4096
+            );
+            if (decompressed_size > 0) {
+                (void)decompressed_size;
+            }
+        }
     } catch (...) {
     }
     return 0;

--- a/tests/fuzz_tar.cpp
+++ b/tests/fuzz_tar.cpp
@@ -16,17 +16,27 @@
 
 #include <cstdint>
 #include <cstddef>
-#include <cstring>
-#include <vector>
-#include "core/odin_types.h"
-#include "odin4/fuzz_utils.h"
+#include "protocol/thor_protocol.h"
+#include "firmware/firmware_package.h"
+#include "odin4/fuzz_helpers.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     try {
-        std::vector<unsigned char> pit_data(size);
-        std::memcpy(pit_data.data(), data, size);
-        PitTable pit_table;
-        fuzz_parse_pit_bytes(pit_table, pit_data);
+        // Test TAR header parsing - 512 byte blocks
+        if (size >= 512) {
+            // Test first block as TAR header
+            fuzz_parse_tar_header(data, 512);
+            
+            // For larger inputs, test consecutive blocks
+            for (size_t i = 0; i + 512 <= size; i += 512) {
+                fuzz_parse_tar_header(data + i, 512);
+            }
+        }
+        
+        // Test MD5 trailer detection
+        if (size > 32) {
+            fuzz_detect_md5_trailer(data, size);
+        }
     } catch (...) {
     }
     return 0;

--- a/tests/fuzz_thor.cpp
+++ b/tests/fuzz_thor.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Llucs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <cstddef>
+#include "protocol/thor_protocol.h"
+#include "odin4/fuzz_helpers.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    try {
+        // Test Thor protocol packet parsing
+        fuzz_parse_thor_packet(data, size);
+        
+        // Also test specific packet types
+        if (size >= sizeof(ThorHandshakePacket)) {
+            auto* pkt = reinterpret_cast<const ThorHandshakePacket*>(data);
+            (void)pkt->magic;
+            (void)pkt->version;
+        }
+        
+        if (size >= sizeof(ThorPitFilePacket)) {
+            auto* pkt = reinterpret_cast<const ThorPitFilePacket*>(data);
+            (void)pkt->pit_file_size;
+        }
+        
+        if (size >= sizeof(ThorResponsePacket)) {
+            auto* pkt = reinterpret_cast<const ThorResponsePacket*>(data);
+            (void)pkt->response_code;
+        }
+    } catch (...) {
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Build

## Testing
- [ ] Builds successfully
- [ ] Manual CLI test
- [ ] Device test (if applicable)

## Notes
