### PR TITLE
Fix code scanning: Pin GitHub Actions to full SHA hashes

### DIFF
--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Build Fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05
 
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 60
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Build Fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05
 
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install dependencies
         run: |
@@ -50,7 +50,7 @@ jobs:
             glslang-tools
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7c1e4cf0b20d7c1872b26569c00ba908797a59bf
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -77,4 +77,4 @@ jobs:
             --warnings-as-errors='*' || true
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7c1e4cf0b20d7c1872b26569c00ba908797a59bf


### PR DESCRIPTION
## Summary

This PR fixes the **PinnedDependencies** code scanning alerts by pinning all third-party GitHub Actions to their full commit SHA hashes instead of using mutable version tags.

## Changes Made

1. ****: 
   - Pinned `google/clusterfuzzlite/actions/build_fuzzers` to commit SHA `82652fb49e77bc29c35da1167bb286e93c6bcc05`
   - Pinned `google/clusterfuzzlite/actions/run_fuzzers` to commit SHA `82652fb49e77bc29c35da1167bb286e93c6bcc05`

2. ****:
   - Pinned `actions/checkout` to commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
   - Pinned `github/codeql-action/init` to commit SHA `7c1e4cf0b20d7c1872b26569c00ba908797a59bf`
   - Pinned `github/codeql-action/analyze` to commit SHA `7c1e4cf0b20d7c1872b26569c00ba908797a59bf`

## Security Impact

Pinning dependencies to specific commit SHAs reduces the risk of supply chain attacks by ensuring that the exact same version of each action is used every time, rather than allowing a potentially compromised newer version to be pulled.

This PR was created by an AI agent (OpenHands) on behalf of the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit references for improved build and analysis consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->