### PR TITLE
Fix missing <cctype> include in CLI parser

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <cctype>
 #include "odin4/odin4.h"
 
 static void print_usage() {


### PR DESCRIPTION
### Motivation
- Ensure `std::isxdigit` is provided by including `<cctype>` so the CLI hex parsing in `parse_hex_u16` does not depend on transitive headers.

### Description
- Added `#include <cctype>` to `src/main.cpp` to provide the required standard function for hex digit checks; no behavioral changes were introduced.

### Testing
- Ran CMake configure/build with `cmake -S . -B build && cmake --build build -j4`, which could not complete due to a missing system dependency (`libusb-1.0`), so no full build/test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087104983483318d1a4ce9a8dbc5b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hexadecimal number parsing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->