### PR TITLE
Fix USB receive timeout retry flow

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -471,7 +471,7 @@ auto UsbDevice::receive_packet(void* data, size_t size, int* actual_length, bool
                 if (timeout_override_ms > 0 || attempt == USB_RETRY_COUNT - 1) {
                     return false;
                 }
-                continue;
+                break;
             }
             log_error("USB packet receive failed (attempt " + std::to_string(attempt + 1) + ")", err);
             if (err == LIBUSB_ERROR_NO_DEVICE) {


### PR DESCRIPTION
### Motivation
- Corrigir o tratamento de `LIBUSB_ERROR_TIMEOUT` em `UsbDevice::receive_packet` para evitar loops internos repetidos e permitir que a lógica de retry externa aplique backoff.

### Description
- Em `src/usb/usb_device.cpp` substituí o `continue` por `break` no caso `LIBUSB_ERROR_TIMEOUT` dentro do loop interno de leitura, fazendo com que a tentativa atual termine e a tentativa externa execute o backoff e nova tentativa.

### Testing
- Executei a configuração/build com `cmake -S . -B build && cmake --build build -j4` e os testes com `ctest --test-dir build --output-on-failure`, porém a configuração falhou devido à ausência do pacote de desenvolvimento `libusb-1.0`, então os testes automatizados não puderam ser executados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087104983483318d1a4ce9a8dbc5b1)