### PR TITLE
Fix malformed include-guard usage in Thor protocol tests

### DIFF
--- a/tests/test_thor_protocol.cpp
+++ b/tests/test_thor_protocol.cpp
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef ODIN4_TESTS_THOR_PROTOCOL_TEST_H
-#define ODIN4_TESTS_THOR_PROTOCOL_TEST_H
-
 #include <cstdint>
 #include <cstring>
 
@@ -37,8 +34,6 @@ inline uint64_t test_swap64(uint64_t v) {
 }
 
 } // namespace
-
-#endif
 
 #include "test_framework.h"
 #include "../src/protocol/thor_protocol.h"


### PR DESCRIPTION
### Motivation
- The test translation unit `tests/test_thor_protocol.cpp` incorrectly used header-style include guards which could hide code behind preprocessor conditions and is not appropriate in a `.cpp` file.

### Description
- Remove the `#ifndef/#define/#endif` header-guard block from `tests/test_thor_protocol.cpp` and keep the helper endianness functions inside an anonymous namespace so the file remains a proper translation unit.

### Testing
- Ran a syntax-only compile check: `g++ -std=c++23 -I./src -I./include -fsyntax-only tests/test_thor_protocol.cpp` which succeeded.
- Attempted full build and test: `cmake -S . -B build && cmake --build build -j && ctest --test-dir build --output-on-failure` which could not complete due to the missing system dependency `libusb-1.0` (project requirement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087104983483318d1a4ce9a8dbc5b1)