### PR TITLE
Potential fix for code scanning alert no. 33: Comparison result is always the same

### DIFF
--- a/src/firmware/firmware_package.cpp
+++ b/src/firmware/firmware_package.cpp
@@ -468,7 +468,7 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
                         return false;
                     }
 
-                    if (src_offset != 0 && src_size > 0) {
+                    if (src_offset != 0) {
                         if (src_offset + src_size > in_buf_size) {
                             log_error("LZ4 scan buffer overflow for " + filename);
                             LZ4F_freeDecompressionContext(scan_ctx);


### PR DESCRIPTION
Potential fix for [https://github.com/Llucs/odin4/security/code-scanning/33](https://github.com/Llucs/odin4/security/code-scanning/33)

General fix: remove or refactor comparisons that are provably constant under current control-flow constraints.

Best fix here (without changing functionality): in `src/firmware/firmware_package.cpp`, simplify line 471 from:
- `if (src_offset != 0 && src_size > 0) {`
to:
- `if (src_offset != 0) {`

This preserves behavior because `src_size > 0` is already guaranteed by the enclosing `while (src_size > 0 && !frame_ended)` and unchanged before this check. No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
