### PR TITLE
Potential fix for code scanning alert no. 41: Poorly documented large function

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -1398,19 +1398,29 @@ auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
 
 auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, const PitEntry& pit_entry,
                                        bool large_partition) -> bool {
+    // Flash a partition from an input stream using the active device protocol.
+    // High-level flow: initialize protocol transfer state, send data in protocol-defined
+    // packet/sequence units, validate acknowledgements, then finalize the flash operation.
     (void) large_partition;
 
+    // Odin legacy mode uses a request/sequence-based transfer model.
+    // We first request file flash mode, then derive how many transfer sequences are needed
+    // from the negotiated packet size and packets-per-sequence values.
     if (protocol_mode == ProtocolMode::OdinLegacy) {
         if (!odin_request_file_flash()) {
             return false;
         }
 
+        // Bytes transferred per sequence = packet_size * packet_count.
+        // A zero value would indicate invalid negotiation/configuration and would lead
+        // to division by zero below, so fail fast.
         const uint64_t sequence_bytes =
             static_cast<uint64_t>(odin_flash_packet_size) * static_cast<uint64_t>(odin_flash_sequence_count);
         if (sequence_bytes == 0) {
             return false;
         }
 
+        // Round up to include the final partial sequence when size is not aligned.
         const uint64_t sequences64 = (size + sequence_bytes - 1) / sequence_bytes;
         if (sequences64 == 0 || sequences64 > 0xFFFFFFFFULL) {
             log_error("Too many legacy sequences for size: " + std::to_string(size));


### PR DESCRIPTION
Potential fix for [https://github.com/Llucs/odin4/security/code-scanning/41](https://github.com/Llucs/odin4/security/code-scanning/41)

To fix this without changing functionality, add concise, intent-focused comments inside `UsbDevice::flash_partition_stream` in `src/usb/usb_device.cpp`, especially at major execution phases:

- function purpose and high-level flow,
- protocol branch behavior (`OdinLegacy` vs alternatives),
- packet/sequence sizing rationale,
- loop and boundary/integrity checks,
- completion/cleanup expectations.

Best approach: insert comments above existing logic blocks (not trailing every line), documenting *why* each block exists and any assumptions (for example, why `sequence_bytes` must be non-zero, and how stream chunks map to flash packets). This increases documentation density and maintainability while preserving exact runtime behavior. No imports, new methods, or dependency additions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal code documentation with clarifying comments for the USB partition flashing sequence transfer model and byte count computation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->