### PR TITLE
Potential fix for code scanning alert no. 34: Comparison result is always the same

### DIFF
--- a/src/firmware/firmware_package.cpp
+++ b/src/firmware/firmware_package.cpp
@@ -587,7 +587,7 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
                     return false;
                 }
 
-                if (src_offset != 0 && src_size > 0) {
+                if (src_offset != 0) {
                     if (src_offset + src_size > in_buf_size) {
                         log_error(std::format("LZ4 buffer overflow for {}", filename));
                         return false;


### PR DESCRIPTION
Potential fix for [https://github.com/Llucs/odin4/security/code-scanning/34](https://github.com/Llucs/odin4/security/code-scanning/34)

General fix: remove or refactor comparisons that are provably constant in the current control-flow context.

Best fix here (no functionality change): in `src/firmware/firmware_package.cpp`, simplify line 590 from:

- `if (src_offset != 0 && src_size > 0) {`

to:

- `if (src_offset != 0) {`

Because this block is already inside `while (src_size > 0)`, the `src_size > 0` conjunct is redundant and always true.

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
