### PR TITLE
Potential fix for code scanning alert no. 40: Poorly documented large function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,12 +115,22 @@ static auto has_any_firmware_files(const OdinConfig& cfg) -> bool {
     return !cfg.bootloader.empty() || !cfg.ap.empty() || !cfg.cp.empty() || !cfg.csc.empty() || !cfg.ums.empty();
 }
 
+// Entry point for the odin4 CLI.
+//
+// High-level flow:
+// 1) Parse command-line options into an OdinConfig instance.
+// 2) Handle informational options that terminate early (-h/-v/-w/-l).
+// 3) Validate option combinations and required arguments.
+// 4) Execute the requested device interaction / flashing workflow.
+// 5) Return a process exit code indicating success or failure.
 auto main(int argc, char** argv) -> int {
     OdinConfig cfg;
 
+    // Phase 1: parse CLI arguments and apply them to cfg.
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
 
+        // Informational flags: print and exit immediately.
         if (arg == "-h") {
             print_usage();
             return 0;


### PR DESCRIPTION
Potential fix for [https://github.com/Llucs/odin4/security/code-scanning/40](https://github.com/Llucs/odin4/security/code-scanning/40)

The best fix is to add concise, high-value documentation comments to `main` that explain the function’s purpose and the major execution phases (parse CLI options, early-exit informational flags, validate inputs, prepare flashing config, and run/return). This addresses the CodeQL finding directly while preserving behavior.

In `src/main.cpp`, update the region immediately above and within `main` (around line 118) by:
- Adding a function-level comment block describing what `main` does and its high-level flow.
- Adding short section comments inside `main` before major logical phases (at minimum before the CLI parsing loop and after parsing, where validation/execution begins).

No imports, new methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code documentation with clarified comment structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->