### PR TITLE
Fix exit code inconsistency between internal ExitCode and public OdinExitCode

### DIFF
--- a/src/core/odin_types.h
+++ b/src/core/odin_types.h
@@ -23,12 +23,12 @@
 
 // Exit codes are part of the CLI contract.
 // 0: success
-// 2: argument/usage error
-// 3: USB/device error
-// 4: firmware/archive/MD5 error
-// 5: PIT/compatibility error
-// 6: flashing/protocol error
-enum class ExitCode : int { Success = 0, Usage = 2, Usb = 3, Firmware = 4, Pit = 5, Protocol = 6 };
+// 1: argument/usage error
+// 2: USB/device error
+// 3: flashing/protocol error
+// 4: PIT/compatibility error
+// 5: firmware/archive/MD5 error
+enum class ExitCode : int { Success = 0, Usage = 1, Usb = 2, Protocol = 3, Pit = 4, Firmware = 5 };
 
 // ============================================================================
 // PARTITION INFORMATION TABLE (PIT)


### PR DESCRIPTION
## Summary

Fixes exit code inconsistency between internal `ExitCode` enum and public `OdinExitCode` enum.

## Problem

The internal `ExitCode` enum (defined in `src/core/odin_types.h`) had different values than the public `OdinExitCode` enum (defined in `include/odin4/odin4.h`):

| Error Type | Internal (before) | Public API | Actual Returned |
|-----------|-------------------|------------|----------------|
| Usage     | 2                 | 1          | 1 (correct)    |
| USB       | 3                 | 2          | 2 (correct)    |
| Firmware  | 4                 | 5          | **5** (was 4) |
| Pit       | 5                 | 4          | **4** (was 5) |
| Protocol | 6                 | 3          | **3** (was 6) |

This caused wrong exit codes to be returned to users and scripts when operations failed.

## Solution

Updated the internal `ExitCode` enum to match the public `OdinExitCode` enum values.
