### PR TITLE
Potential fix for code scanning alert no. 42: Poorly documented large function

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -253,9 +253,14 @@ auto UsbDevice::open_device(const std::string& specific_path) -> bool {
 }
 
 auto UsbDevice::open_device(const std::string& specific_path, const UsbSelectionCriteria& criteria) -> bool {
+    // Reset open-status fields for this attempt. Any early return below must
+    // leave these members describing the current failure (if any).
     last_open_error = UsbOpenError::None;
     last_open_libusb_err = 0;
 
+    // Tear down any previously opened handle/interface so this call starts from
+    // a clean state. If we detached a kernel driver earlier, attempt to restore
+    // it before closing the handle.
     if (handle != nullptr) {
         libusb_release_interface(handle, interface_number);
         if (kernel_driver_detached) {
@@ -265,11 +270,14 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
         libusb_close(handle);
         handle = nullptr;
     }
+
+    // Free any stale enumeration results from a prior open attempt.
     if (device_list != nullptr) {
         libusb_free_device_list(device_list, 1);
         device_list = nullptr;
     }
 
+    // Ensure the process-wide libusb context exists before enumeration.
     if (!ensure_libusb_initialized()) {
         last_open_error = UsbOpenError::Other;
         last_open_libusb_err = LIBUSB_ERROR_OTHER;
@@ -277,6 +285,8 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
         return false;
     }
 
+    // Enumerate all currently visible USB devices. The resulting device list is
+    // consumed by the matching/selection logic in the remainder of this method.
     ssize_t cnt = libusb_get_device_list(g_libusb_ctx, &device_list);
     if (cnt < 0) {
         last_open_error = UsbOpenError::Other;


### PR DESCRIPTION
Potential fix for [https://github.com/Llucs/odin4/security/code-scanning/42](https://github.com/Llucs/odin4/security/code-scanning/42)

Add concise, phase-oriented comments inside `UsbDevice::open_device(const std::string&, const UsbSelectionCriteria&)` to document *why* each major block exists: reset previous state, release old resources safely, initialize libusb, enumerate devices, select candidate interface/device, open/configure claimed interface, and set/report error outcomes.

Best fix without functional change:
- Edit only `src/usb/usb_device.cpp`.
- Add comments immediately above major logic blocks in the function starting at line 255.
- Do **not** alter control flow, variable values, or API calls.
- Keep comments durable and intent-focused (not line-by-line restatements).

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation for USB device initialization and error handling processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->