### PR TITLE
Fix PIT dump double-read and reboot without end_session

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -1071,6 +1071,7 @@ auto UsbDevice::end_file_transfer(uint32_t partition_id) -> bool {
 auto UsbDevice::send_control(uint32_t control_type) -> bool {
     if (protocol_mode == ProtocolMode::OdinLegacy) {
         if (control_type == THOR_CONTROL_REBOOT) {
+            (void) odin_end_session();
             return odin_reboot();
         }
         if (control_type == THOR_CONTROL_REDOWNLOAD) {
@@ -1387,18 +1388,9 @@ auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
             return false;
         }
 
-        int got = 0;
-        std::vector<unsigned char> data(block, 0);
-        if (!receive_packet(data.data(), data.size(), &got, false, data.size(), 5000)) {
-            return false;
-        }
-        if (got != static_cast<int>(data.size())) {
-            return false;
-        }
-
         size_t off = static_cast<size_t>(i) * block;
-        size_t copy = std::min(static_cast<size_t>(got), pit_out.size() - off);
-        std::memcpy(pit_out.data() + off, data.data(), copy);
+        size_t copy = std::min({rsp.size(), pit_out.size() - off, static_cast<size_t>(block)});
+        std::memcpy(pit_out.data() + off, rsp.data(), copy);
     }
 
     if (!odin_command(0x65, 0x03, nullptr, 0, rsp, 5000)) {


### PR DESCRIPTION
Fixes #99 and #100

## Issue #99: Failed to send reboot command
- Reference implementations (Heimdall, Brokkr, Thor) all send end_session (0x67,0x00) before reboot (0x67,0x01) in Odin legacy mode.
- When --reboot was used without firmware files, end_session was never called.
- **Fix**: call odin_end_session() before odin_reboot() in send_control().

## Issue #100: Failed to retrieve or parse PIT from device
- odin_dump_pit() used odin_command(0x65,0x02) which already reads the 500-byte PIT block into rsp, but then tried to read it again with receive_packet(), causing a 5-second timeout.
- **Fix**: use the data already in rsp instead of reading again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management in Odin legacy mode by ensuring sessions are properly terminated and cleaned up before executing reboot operations.

* **Refactor**
  * Optimized PIT dump operations with direct memory transfer implementation, eliminating unnecessary intermediate buffer stages and improving overall data transfer efficiency and resource utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->