### PR TITLE
Add LZ4 compressed download support for Odin legacy mode

### DIFF
--- a/src/firmware/firmware_package.cpp
+++ b/src/firmware/firmware_package.cpp
@@ -670,6 +670,47 @@ auto process_lz4_streaming(std::ifstream& file, uint64_t compressed_size, UsbDev
     return true;
 }
 
+static auto parse_lz4_frame_header(std::ifstream& file, uint64_t& content_size, uint32_t& max_block_size) -> bool {
+    content_size = 0;
+    max_block_size = 0;
+
+    unsigned char magic[4];
+    if (!read_exact(file, magic, 4)) return false;
+    if (magic[0] != 0x04 || magic[1] != 0x22 || magic[2] != 0x4D || magic[3] != 0x18) {
+        log_error("Invalid LZ4 magic");
+        return false;
+    }
+
+    unsigned char flg_bd[2];
+    if (!read_exact(file, flg_bd, 2)) return false;
+
+    unsigned char flg = flg_bd[0];
+    unsigned char bd = flg_bd[1];
+    max_block_size = (bd >> 4) & 0x07;
+    if (max_block_size == 4) max_block_size = 65536;
+    else if (max_block_size == 5) max_block_size = 262144;
+    else if (max_block_size == 6) max_block_size = 1048576;
+    else if (max_block_size == 7) max_block_size = 4194304;
+    else return false;
+
+    if ((flg & 0x08u)) {
+        unsigned char cs[8];
+        if (!read_exact(file, cs, 8)) return false;
+        for (int i = 0; i < 8; ++i)
+            content_size |= static_cast<uint64_t>(cs[i]) << (i * 8);
+    }
+
+    if ((flg & 0x01u)) {
+        unsigned char dict[4];
+        if (!read_exact(file, dict, 4)) return false;
+    }
+
+    unsigned char hc[1];
+    if (!read_exact(file, hc, 1)) return false;
+
+    return true;
+}
+
 auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const PitTable& pit_table, bool do_flash,
                       bool allow_unknown) -> ExitCode {
     // End-to-end TAR processing entry point:
@@ -961,12 +1002,123 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
                     " (ID " + std::to_string(pit_entry->identifier) + ")");
 
         if (is_lz4) {
-            if (usb_device.is_odin_legacy() && do_flash) {
-                log_error("LZ4 images are not supported in Odin legacy mode");
-                return ExitCode::Protocol;
-            }
-            if (!process_lz4_streaming(file, data_size, usb_device, filename, is_large, do_flash)) {
-                return do_flash ? ExitCode::Protocol : ExitCode::Firmware;
+            if (usb_device.is_odin_legacy() && do_flash &&
+                usb_device.is_compressed_download_supported()) {
+                const std::streampos lz4_entry = file.tellg();
+                if (lz4_entry < 0) {
+                    log_error("Failed to get file position for LZ4 entry: " + filename);
+                    return ExitCode::Firmware;
+                }
+                uint64_t content_size = 0;
+                uint32_t max_block_size = 0;
+                if (!parse_lz4_frame_header(file, content_size, max_block_size)) {
+                    log_error("Failed to parse LZ4 frame header for " + filename);
+                    return ExitCode::Firmware;
+                }
+                const std::streampos data_start = file.tellg();
+                if (data_start < 0) {
+                    log_error("Failed to get data start position for " + filename);
+                    return ExitCode::Firmware;
+                }
+                uint64_t header_bytes = static_cast<uint64_t>(data_start - lz4_entry);
+                if (content_size == 0 || header_bytes >= data_size) {
+                    log_error("Invalid LZ4 content or compressed size for " + filename);
+                    return ExitCode::Firmware;
+                }
+                uint64_t compressed_data_size = data_size - header_bytes;
+                if (!usb_device.flash_partition_stream_compressed(file, compressed_data_size, *pit_entry,
+                                                                   is_large, content_size, max_block_size)) {
+                    return ExitCode::Protocol;
+                }
+                file.clear();
+                file.seekg(lz4_entry);
+                file.seekg(static_cast<std::streamoff>(data_size), std::ios::cur);
+            } else if (usb_device.is_odin_legacy() && do_flash) {
+                const std::streampos lz4_entry = file.tellg();
+                char tmp_path[] = "/tmp/odin4_decomp_XXXXXX";
+                int tmp_fd = mkstemp(tmp_path);
+                if (tmp_fd < 0) {
+                    log_error("Failed to create temp file for LZ4 decompression");
+                    return ExitCode::Firmware;
+                }
+
+                LZ4F_decompressionContext_t dctx;
+                LZ4F_errorCode_t lz4_err = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
+                if (LZ4F_isError(lz4_err) != 0U) {
+                    log_error(std::string("LZ4 context creation failed: ") + LZ4F_getErrorName(lz4_err));
+                    close(tmp_fd);
+                    unlink(tmp_path);
+                    return ExitCode::Firmware;
+                }
+
+                size_t in_buf_sz = 1024u * 1024u;
+                size_t out_buf_sz = 4u * 1024u * 1024u;
+                std::vector<unsigned char> in_buf(in_buf_sz);
+                std::vector<unsigned char> out_buf(out_buf_sz);
+                uint64_t remaining = data_size;
+                uint64_t total_decompressed = 0;
+                bool frame_ended = false;
+
+                while (remaining > 0 && !frame_ended) {
+                    auto to_read = static_cast<size_t>(std::min<uint64_t>(in_buf_sz, remaining));
+                    file.read(reinterpret_cast<char*>(in_buf.data()), static_cast<std::streamsize>(to_read));
+                    size_t src_sz = static_cast<size_t>(file.gcount());
+                    if (src_sz == 0) break;
+                    remaining -= src_sz;
+                    size_t src_off = 0;
+
+                    while (src_sz > 0 && !frame_ended) {
+                        size_t dst_sz = out_buf_sz;
+                        size_t src_consumed = src_sz;
+                        lz4_err = LZ4F_decompress(dctx, out_buf.data(), &dst_sz,
+                                                   in_buf.data() + src_off, &src_consumed, nullptr);
+                        if (LZ4F_isError(lz4_err) != 0U) {
+                            log_error(std::string("LZ4 decompression error for ") + filename + ": " +
+                                      LZ4F_getErrorName(lz4_err));
+                            LZ4F_freeDecompressionContext(dctx);
+                            close(tmp_fd);
+                            unlink(tmp_path);
+                            return ExitCode::Firmware;
+                        }
+                        if (dst_sz > 0) {
+                            write(tmp_fd, out_buf.data(), dst_sz);
+                            total_decompressed += dst_sz;
+                        }
+                        src_off += src_consumed;
+                        src_sz -= src_consumed;
+                        if (lz4_err == 0) frame_ended = true;
+                    }
+                }
+
+                LZ4F_freeDecompressionContext(dctx);
+                close(tmp_fd);
+
+                if (!frame_ended) {
+                    log_error("LZ4 frame not completed for " + filename);
+                    unlink(tmp_path);
+                    return ExitCode::Firmware;
+                }
+
+                std::ifstream tmp_file(tmp_path, std::ios::binary);
+                if (!tmp_file) {
+                    log_error("Failed to open decompressed temp file for " + filename);
+                    unlink(tmp_path);
+                    return ExitCode::Firmware;
+                }
+
+                bool flash_ok = usb_device.flash_partition_stream(tmp_file, total_decompressed, *pit_entry, is_large);
+                tmp_file.close();
+                unlink(tmp_path);
+
+                if (!flash_ok) return ExitCode::Protocol;
+
+                file.clear();
+                file.seekg(lz4_entry);
+                file.seekg(static_cast<std::streamoff>(data_size), std::ios::cur);
+            } else {
+                if (!process_lz4_streaming(file, data_size, usb_device, filename, is_large, do_flash)) {
+                    return do_flash ? ExitCode::Protocol : ExitCode::Firmware;
+                }
             }
         } else {
             if (do_flash) {

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -1224,9 +1224,12 @@ auto UsbDevice::odin_begin_session() -> bool {
         return false;
     }
 
-    uint16_t version = 0;
-    std::memcpy(&version, rsp.data() + 6, sizeof(version));
-    version = static_cast<uint16_t>(le16toh(version));
+    uint32_t version_word = 0;
+    std::memcpy(&version_word, rsp.data() + 4, sizeof(version_word));
+    version_word = le32toh(version_word);
+
+    uint16_t version = static_cast<uint16_t>((version_word >> 16) & 0xFFFF);
+    odin_supports_compressed_download = (version_word & 0x8000u) != 0;
 
     if (version <= 1) {
         odin_flash_timeout_ms = 60000;
@@ -1356,6 +1359,56 @@ auto UsbDevice::odin_end_sequence_flash(const PitEntry& pit_entry, uint32_t real
         return false;
     }
     return odin_fail_check(rsp, "EndSequenceFlash", true);
+}
+
+auto UsbDevice::odin_request_file_flash_compressed() -> bool {
+    std::vector<unsigned char> rsp;
+    if (!odin_command(0x66, 0x05, nullptr, 0, rsp, USB_TIMEOUT_CONTROL)) {
+        return false;
+    }
+    return odin_fail_check(rsp, "RequestFileFlashCompressed", false);
+}
+
+auto UsbDevice::odin_request_sequence_flash_compressed(uint32_t aligned_size) -> bool {
+    std::vector<unsigned char> rsp;
+    uint32_t le_sz = h_to_le32(aligned_size);
+    if (!odin_command(0x66, 0x06, &le_sz, sizeof(le_sz), rsp, USB_TIMEOUT_CONTROL)) {
+        return false;
+    }
+    return odin_fail_check(rsp, "RequestSequenceFlashCompressed", false);
+}
+
+auto UsbDevice::odin_end_sequence_flash_compressed(const PitEntry& pit_entry, uint32_t decomp_size,
+                                                   uint32_t is_last) -> bool {
+    std::vector<unsigned char> rsp;
+    std::vector<unsigned char> payload(64, 0);
+
+    auto w32 = [&](size_t off, uint32_t v) {
+        uint32_t le = h_to_le32(v);
+        std::memcpy(payload.data() + off, &le, sizeof(le));
+    };
+
+    if (pit_entry.binary_type == 1) {
+        w32(0, 0x01);
+        w32(4, decomp_size);
+        w32(8, 0U);
+        w32(12, pit_entry.device_type);
+        w32(16, (is_last != 0U) ? 1U : 0U);
+    } else {
+        w32(0, 0x00);
+        w32(4, decomp_size);
+        w32(8, 0U);
+        w32(12, pit_entry.device_type);
+        w32(16, pit_entry.identifier);
+        w32(20, (is_last != 0U) ? 1U : 0U);
+        w32(24, 0U);
+        w32(28, 0U);
+    }
+
+    if (!odin_command(0x66, 0x07, payload.data(), 32, rsp, odin_flash_timeout_ms)) {
+        return false;
+    }
+    return odin_fail_check(rsp, "EndSequenceFlashCompressed", true);
 }
 
 auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
@@ -1522,6 +1575,111 @@ auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, cons
                 last_pct = pct;
             }
         }
+    }
+
+    return true;
+}
+
+auto UsbDevice::flash_partition_stream_compressed(std::istream& stream, uint64_t compressed_size,
+                                                   const PitEntry& pit_entry, bool large_partition,
+                                                   uint64_t decompressed_size, uint32_t max_block_size) -> bool {
+    (void) large_partition;
+
+    if (protocol_mode != ProtocolMode::OdinLegacy) {
+        return false;
+    }
+
+    if (!odin_request_file_flash_compressed()) {
+        return false;
+    }
+
+    const uint64_t sequence_bytes =
+        static_cast<uint64_t>(odin_flash_packet_size) * static_cast<uint64_t>(odin_flash_sequence_count);
+    if (sequence_bytes == 0) return false;
+
+    std::vector<unsigned char> part(static_cast<size_t>(odin_flash_packet_size), 0);
+
+    uint64_t comp_remaining = compressed_size;
+    uint64_t decomp_remaining = decompressed_size;
+    uint32_t expected_index = 0;
+    bool done = false;
+
+    while (!done && comp_remaining > 0) {
+        uint64_t seq_comp = 0;
+        uint64_t seq_decomp = 0;
+        std::vector<unsigned char> seq_buf;
+        seq_buf.reserve(static_cast<size_t>(sequence_bytes + 4096));
+
+        uint64_t comp_limit = std::min(comp_remaining, sequence_bytes);
+
+        while (comp_limit > 0 && !done) {
+            unsigned char hdr[4];
+            stream.read(reinterpret_cast<char*>(hdr), 4);
+            if (static_cast<size_t>(stream.gcount()) != 4) return false;
+
+            uint32_t block_sz = static_cast<uint32_t>(hdr[0]) | (static_cast<uint32_t>(hdr[1]) << 8) |
+                                (static_cast<uint32_t>(hdr[2]) << 16) | (static_cast<uint32_t>(hdr[3]) << 24);
+
+            if (block_sz == 0) {
+                seq_buf.insert(seq_buf.end(), hdr, hdr + 4);
+                seq_comp += 4;
+                comp_limit -= 4;
+                done = true;
+                break;
+            }
+
+            uint32_t payload = block_sz & 0x7FFFFFFFu;
+            if (4 + payload > comp_limit) {
+                stream.seekg(-4, std::ios::cur);
+                break;
+            }
+
+            comp_limit -= 4 + payload;
+            seq_buf.insert(seq_buf.end(), hdr, hdr + 4);
+
+            if (payload > 0) {
+                size_t old = seq_buf.size();
+                seq_buf.resize(old + payload);
+                stream.read(reinterpret_cast<char*>(seq_buf.data() + old), static_cast<std::streamsize>(payload));
+                if (static_cast<size_t>(stream.gcount()) != payload) return false;
+            }
+
+            seq_comp += 4 + payload;
+
+            uint64_t block_decomp = (block_sz & 0x80000000u)
+                                        ? static_cast<uint64_t>(payload)
+                                        : std::min<uint64_t>(static_cast<uint64_t>(max_block_size),
+                                                             decomp_remaining - seq_decomp);
+            seq_decomp += block_decomp;
+            comp_remaining -= 4 + payload;
+        }
+
+        if (seq_comp == 0) break;
+
+        uint32_t aligned = static_cast<uint32_t>(seq_comp);
+        if (aligned % odin_flash_packet_size != 0) {
+            aligned += odin_flash_packet_size - (aligned % odin_flash_packet_size);
+        }
+        seq_buf.resize(aligned, 0);
+
+        if (!odin_request_sequence_flash_compressed(aligned)) return false;
+
+        uint32_t parts = aligned / static_cast<uint32_t>(odin_flash_packet_size);
+        for (uint32_t j = 0; j < parts; ++j) {
+            std::memcpy(part.data(), seq_buf.data() + j * static_cast<size_t>(odin_flash_packet_size),
+                        static_cast<size_t>(odin_flash_packet_size));
+            if (!odin_send_file_part_and_ack(part.data(), static_cast<size_t>(odin_flash_packet_size),
+                                             expected_index++)) {
+                return false;
+            }
+        }
+
+        bool is_last = done || (comp_remaining == 0);
+        uint32_t actual_decomp = static_cast<uint32_t>(std::min<uint64_t>(seq_decomp, decomp_remaining));
+        if (!odin_end_sequence_flash_compressed(pit_entry, actual_decomp, is_last ? 1U : 0U)) {
+            return false;
+        }
+        decomp_remaining -= actual_decomp;
     }
 
     return true;

--- a/src/usb/usb_device.h
+++ b/src/usb/usb_device.h
@@ -72,11 +72,15 @@ class UsbDevice {
     int odin_flash_packet_size = 1048576;
     int odin_flash_sequence_count = 30;
     bool odin_supports_zlp = true;
+    bool odin_supports_compressed_download = false;
 
     auto odin_legacy_handshake() -> bool;
     auto odin_begin_session() -> bool;
     auto odin_end_session() -> bool;
     auto odin_reboot() -> bool;
+    auto odin_request_file_flash_compressed() -> bool;
+    auto odin_request_sequence_flash_compressed(uint32_t aligned_size) -> bool;
+    auto odin_end_sequence_flash_compressed(const PitEntry& pit_entry, uint32_t real_size, uint32_t is_last) -> bool;
     auto odin_set_total_bytes(uint64_t total_bytes) -> bool;
     auto odin_reset_flash_count() -> bool;
     auto odin_request_file_flash() -> bool;
@@ -114,6 +118,9 @@ class UsbDevice {
     [[nodiscard]] auto is_odin_legacy() const -> bool {
         return protocol_mode == ProtocolMode::OdinLegacy;
     }
+    [[nodiscard]] auto is_compressed_download_supported() const -> bool {
+        return odin_supports_compressed_download;
+    }
     auto request_device_type() -> bool;
     auto begin_session() -> bool;
     auto end_session() -> bool;
@@ -121,6 +128,9 @@ class UsbDevice {
     auto receive_pit_table(PitTable& pit_table) -> bool;
     auto flash_partition_stream(std::istream& stream, uint64_t size, const PitEntry& pit_entry,
                                 bool large_partition) -> bool;
+    auto flash_partition_stream_compressed(std::istream& stream, uint64_t compressed_size, const PitEntry& pit_entry,
+                                           bool large_partition, uint64_t decompressed_size,
+                                           uint32_t max_block_size = 1048576) -> bool;
     auto send_file_part_chunk(const void* data, size_t size, uint32_t chunk_index,
                               bool large_partition = false) -> bool;
     auto send_file_part_header(uint64_t total_size) -> bool;


### PR DESCRIPTION
## Summary

Adds support for flashing LZ4-compressed images in Odin legacy mode via compressed sub-commands (0x66/0x05-0x07), matching Brokkr protocol extension.

## Changes

### USB layer (src/usb/usb_device.h/.cpp)
- **Version word parsing**: reads uint32 LE at offset 4 instead of uint16 at offset 6 in `odin_begin_session()`. Extracts protocol version (upper 16 bits) and compressed download capability (bit 15).
- **Three new private commands**: `odin_request_file_flash_compressed` (0x05), `odin_request_sequence_flash_compressed` (0x06), `odin_end_sequence_flash_compressed` (0x07) — payload format matches the existing uncompressed end-sequence command, with `is_last` field dynamically set per sequence.
- **New public method `flash_partition_stream_compressed()`**: reads LZ4 block headers from the stream, groups complete blocks into sequences bounded by negotiated `sequence_bytes` capacity, tracks per-sequence decompressed size using LZ4 frame max_block_size.

### Firmware package (src/firmware/firmware_package.cpp)
- **`parse_lz4_frame_header()`**: extracts content size and max block size from LZ4 frame header.
- **Three-way LZ4 branch in `process_tar_file()`**:
  1. Odin legacy + device supports compressed: parse header, call `flash_partition_stream_compressed()`
  2. Odin legacy + no support: decompress to temp file via `LZ4F_decompress`, flash uncompressed
  3. Thor mode: existing `process_lz4_streaming()` path (unchanged)

## Behavioral changes
- Odin legacy mode: LZ4 images no longer produce an error; flashed via compressed sub-commands or decompressed to temp as fallback
- Thor mode: unchanged

## Testing
Build requires GCC 13+ (C++23 standard). Environment has GCC 11.4.0 — cannot verify compilation. Code reviewed manually.