### PR TITLE
docs: fix inconsistencies between documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ If odin4 reports `LIBUSB_ERROR_ACCESS` during operation, it indicates a permissi
     ```
 3.  **Reconnect your device**: Unplug and then re-plug your Samsung device (in Download Mode) to apply the new permissions.
 
-This rule specifically targets known Samsung Download Mode USB Vendor IDs (`04e8`) and Product IDs (`6601`, `685d`, `68c3`) to grant appropriate access.
+This rule specifically targets known Samsung Download Mode USB Vendor IDs (`04e8`) and Product IDs (`6601`, `685d`, `68c3`, `68ef`, `4eee`, `4eef`) to grant appropriate access.
 
 ## Project Status
 

--- a/docs/LIBRARY_DOCUMENTATION.md
+++ b/docs/LIBRARY_DOCUMENTATION.md
@@ -105,6 +105,25 @@ Retrieves the version string of the Odin4 library.
 -   **Parameters**: None
 -   **Returns**: `const char*` - A C-style string representing the library's version.
 
+#### `void odin4_set_log_callback(OdinLogCallback callback)`
+Sets a custom callback function to receive log messages from the library. This allows integrators to route odin4's log output to their own logging system instead of the default console output.
+
+-   **Parameters**: `callback` - A function pointer of type `OdinLogCallback`. Pass `nullptr` to reset to the default console logger.
+-   **Returns**: `void`
+
+```cpp
+typedef void (*OdinLogCallback)(int level, const char* message);
+```
+
+The `level` parameter uses the following values:
+| Value | Level    |
+| :---- | :------- |
+| 0     | Error    |
+| 1     | Warning  |
+| 2     | Info     |
+| 3     | Verbose  |
+| 4     | Debug    |
+
 ## Usage Example
 
 The following C++ example demonstrates how to initialize the library, list devices, and perform a flashing operation (or dry-run).
@@ -160,6 +179,12 @@ int main() {
 
 To compile an application that uses the Odin4 library, you will typically need to include the header directory and link against the `libodin4` library. Assuming `libodin4.so` and `odin4.h` are in `lib/` and `include/odin4/` relative to your project, respectively:
 
+**Shared library (`libodin4.so`):**
+```bash
+g++ my_app.cpp -o my_app -I./include -L./lib -lodin4 -lusb-1.0
+```
+
+**Static library (`libodin4.a`):**
 ```bash
 g++ my_app.cpp -o my_app -I./include -L./lib -lodin4 -lusb-1.0 -lcryptopp -lpthread -ldl
 ```
@@ -168,5 +193,5 @@ g++ my_app.cpp -o my_app -I./include -L./lib -lodin4 -lusb-1.0 -lcryptopp -lpthr
 -   `-L./lib`: Specifies the directory containing `libodin4.so` or `libodin4.a`.
 -   `-lodin4`: Links against the Odin4 library.
 -   `-lusb-1.0`: Links against the libusb-1.0 library.
--   `-lcryptopp`: Links against the Crypto++ library.
+-   `-lcryptopp`: Links against the Crypto++ library (only needed when linking against the static library).
 -   `-lpthread -ldl`: Additional system libraries that might be required for linking, especially on Linux systems with shared libraries.

--- a/docs/THOR_PROTOCOL.md
+++ b/docs/THOR_PROTOCOL.md
@@ -51,9 +51,15 @@ The following table lists the identified packet types used within the Thor proto
 | `THOR_PACKET_RECEIVE_FILE_PART` | `0x000A`              | Acknowledgment of file part reception.          |
 | `THOR_PACKET_CONTROL`      | `0x000B`              | Control commands (e.g., Reboot).                |
 
+> **Note on Protocol Versions:** Sections 3 and 4–8 describe two distinct but related protocols.
+> **Section 3** defines the **Thor** packet types (`0x0001`–`0x000B`) used in modern Samsung devices.
+> **Sections 4–8** document the **Odin legacy** command protocol (`0x64`–`0x69`), an older binary
+> command format used by earlier bootloaders. The odin4 tool auto-detects which protocol the
+> device speaks after the initial handshake.
+
 ## 4. Session Management
 
-Session management within the Thor protocol involves initiating and terminating communication sessions, negotiating protocol versions, and configuring transfer parameters.
+Session management within the Odin legacy protocol involves initiating and terminating communication sessions, negotiating protocol versions, and configuring transfer parameters.
 
 ### 4.1. Session Initiation (`0x64`)
 
@@ -135,7 +141,7 @@ This command informs the device about the total size of the data that will be tr
 | `0x67`        | 32-bit Integer | Packet type.                                    |
 | `0x00`        | 32-bit Integer | Status code (0 = Success).                      |
 
-## 5. Partition Information Table (PIT)
+## 5. Partition Information Table (PIT) [Odin Legacy]
 
 The Partition Information Table (PIT) file is a critical component that describes the storage layout of the device, defining partitions and their attributes.
 
@@ -190,7 +196,7 @@ A PIT file begins with a 28-byte header, followed by a variable number of 132-by
 3.  **Send PIT Data**: The raw buffer of the PIT file is transferred to the device.
 4.  **End PIT Flash**: The host sends `0x65` with command `0x03` to signal the completion of the flash operation.
 
-## 6. File Transfer (Flashing)
+## 6. File Transfer (Flashing) [Odin Legacy]
 
 Firmware file transfers (`0x66`) are structured into sequences, with each sequence further divided into smaller parts.
 
@@ -282,9 +288,9 @@ After all parts of a sequence have been transferred, the host must signal the en
 | `0x66`        | 32-bit Integer | Packet type.                                    |
 | `0x00`        | 32-bit Integer | Status code.                                    |
 
-## 7. Device Information
+## 7. Device Information [Odin Legacy]
 
-The Thor protocol facilitates the extraction of detailed device information (`0x69`).
+The Odin legacy protocol facilitates the extraction of detailed device information (`0x69`).
 
 ### 7.1. Information Structure
 
@@ -322,7 +328,7 @@ Device information is structured with a header followed by arrays of location an
 *   **Dump Block (`0x01`)**: Requests a 500-byte block by passing the block index. The device responds with the raw data for that block.
 *   **End Dump (`0x02`)**: Terminates the information extraction process.
 
-## 8. Error Handling
+## 8. Error Handling [Odin Legacy]
 
 In the event of an error during any operation, the device signals the failure by setting the first byte of its response to `0xFF`. The specific error code is then provided as a 32-bit integer at offset 4 of the response.
 

--- a/udev/60-odin4.rules
+++ b/udev/60-odin4.rules
@@ -1,4 +1,7 @@
-# Samsung Download Mode devices (historical IDs; based on public Heimdall udev rules)
+# Samsung Download Mode devices (based on public Heimdall udev rules and community reports)
 SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="6601", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="685d", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="68c3", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="68ef", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="4eee", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", ATTR{idProduct}=="4eef", MODE="0660", TAG+="uaccess", GROUP="plugdev"


### PR DESCRIPTION
## Summary

Fixes 5 inconsistencies found between documentation and source code.

### Changes

1. **udev/60-odin4.rules & README.md**: Added missing Samsung Download Mode PIDs (`68ef`, `4eee`, `4eef`) already present in source code but missing from udev rules and README.

2. **docs/LIBRARY_DOCUMENTATION.md**: Added documentation for `odin4_set_log_callback()` and `OdinLogCallback` — public API function that was declared in `odin4.h` but completely undocumented.

3. **docs/THOR_PROTOCOL.md**: Added clarification note about dual protocols (Thor vs Odin legacy). Marked legacy sections with `[Odin Legacy]`.

4. **docs/LIBRARY_DOCUMENTATION.md**: Fixed build command examples to distinguish shared vs static library linking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated library documentation with custom logging callback API
  * Clarified protocol documentation distinguishing Thor and Odin legacy protocols
  * Updated build instructions for shared/static library linking
  * Updated Linux USB device permissions guide

* **Device Support**
  * Added support for additional Samsung Download Mode USB devices

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Llucs/odin4/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->