### PR TITLE
Fix protocol errors: binary_type, timeouts, ZLP, PIT sync, PIDs

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -1398,7 +1398,8 @@ auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
     {
         char zlp_buf[64];
         int actual = 0;
-        bulk_read_once(zlp_buf, sizeof(zlp_buf), &actual, 100);
+        libusb_bulk_transfer(handle, endpoint_in, reinterpret_cast<unsigned char*>(zlp_buf),
+                             static_cast<int>(sizeof(zlp_buf)), &actual, 100);
     }
 
     if (!odin_command(0x65, 0x03, nullptr, 0, rsp, 5000)) {

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -122,7 +122,9 @@ auto UsbDevice::bulk_write_all(const void* data, size_t size, int timeout_ms) ->
         }
         if (offset == size) {
             if (odin_supports_zlp && endpoint_out_max_packet != 0 && (size % endpoint_out_max_packet) == 0) {
-                send_zlp(timeout_ms);
+                if (!send_zlp(timeout_ms)) {
+                    odin_supports_zlp = false;
+                }
             }
             return true;
         }
@@ -1229,11 +1231,11 @@ auto UsbDevice::odin_begin_session() -> bool {
     version = static_cast<uint16_t>(le16toh(version));
 
     if (version <= 1) {
-        odin_flash_timeout_ms = 60000;
+        odin_flash_timeout_ms = 30000;
         odin_flash_packet_size = 131072;
         odin_flash_sequence_count = 240;
     } else {
-        odin_flash_timeout_ms = 180000;
+        odin_flash_timeout_ms = 120000;
         odin_flash_packet_size = 1048576;
         odin_flash_sequence_count = 30;
 
@@ -1338,13 +1340,13 @@ auto UsbDevice::odin_end_sequence_flash(const PitEntry& pit_entry, uint32_t real
     if (pit_entry.binary_type == 1) {
         w32(0, 0x01);
         w32(4, real_size);
-        w32(8, 0U);
+        w32(8, pit_entry.binary_type);
         w32(12, pit_entry.device_type);
         w32(16, (is_last != 0U) ? 1U : 0U);
     } else {
         w32(0, 0x00);
         w32(4, real_size);
-        w32(8, 0U);
+        w32(8, pit_entry.binary_type);
         w32(12, pit_entry.device_type);
         w32(16, pit_entry.identifier);
         w32(20, (is_last != 0U) ? 1U : 0U);
@@ -1391,6 +1393,12 @@ auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
         size_t off = static_cast<size_t>(i) * block;
         size_t copy = std::min({rsp.size(), pit_out.size() - off, static_cast<size_t>(block)});
         std::memcpy(pit_out.data() + off, rsp.data(), copy);
+    }
+
+    {
+        char zlp_buf[64];
+        int actual = 0;
+        bulk_read_once(zlp_buf, sizeof(zlp_buf), &actual, 100);
     }
 
     if (!odin_command(0x65, 0x03, nullptr, 0, rsp, 5000)) {

--- a/src/usb/usb_device.h
+++ b/src/usb/usb_device.h
@@ -32,7 +32,7 @@
 #define USB_TIMEOUT_BULK 120000
 #define USB_TIMEOUT_CONTROL 10000
 
-static constexpr std::array<uint16_t, 3> SAMSUNG_DOWNLOAD_PIDS{{0x6601, 0x685D, 0x68C3}};
+static constexpr std::array<uint16_t, 6> SAMSUNG_DOWNLOAD_PIDS{{0x6601, 0x685D, 0x68C3, 0x68EF, 0x4EEE, 0x4EEF}};
 
 struct UsbSelectionCriteria {
     bool has_vid = false;


### PR DESCRIPTION
## Summary

Fixes 5 protocol bugs identified in the error analysis report.

### Changes

1. **Bug 1 (CRITICAL)** - `odin_end_sequence_flash`: binary_type always 0
   - Replaced hardcoded `0U` with `pit_entry.binary_type` at payload offset 8
   - Bootloader uses binary_type to distinguish AP (0) from CP (1/modem)
   - Reference: brokkr-flash `odin_cmd.cpp:285` (`data[2] = bin_type`)

2. **Bug 2** - Incorrect flash timeouts
   - Version <= 1: 60000ms -> 30000ms
   - Version >= 2: 180000ms -> 120000ms
   - Reference: Thor implementation

3. **Bug 3** - ZLP never disabled on failure
   - Wrap `send_zlp()` with error check, set `odin_supports_zlp = false` on failure
   - Reference: Thor pattern (catch and disable ZLP on error)

4. **Bug 4** - PIT dump without reading ZLP after data
   - Insert ZLP read via `bulk_read_once` before `EndPitDump` command
   - Reference: brokkr-flash `odin_cmd.cpp:230` (`recv_zlp()` after PIT data)

5. **Bug 5** - Incomplete Samsung PIDs
   - Expanded `SAMSUNG_DOWNLOAD_PIDS` from 3 to 6 entries, adding `0x68EF`, `0x4EEE`, `0x4EEF`

All 43 existing tests pass.
