### PR TITLE
Fix BeginSession response ordering, PIT dump validation, send_control, and alt_setting

### DIFF
--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -165,11 +165,11 @@ auto UsbDevice::end_file_transfer(uint32_t partition_id) -> bool {
 
 auto UsbDevice::send_control(uint32_t control_type) -> bool {
     if (control_type == ODIN_CONTROL_REBOOT) {
-        (void) odin_end_session();
         return odin_reboot();
     }
     if (control_type == ODIN_CONTROL_REDOWNLOAD) {
         log_warn("Redownload is not supported.");
+        return false;
     }
     return true;
 }
@@ -265,7 +265,16 @@ auto UsbDevice::odin_begin_session() -> bool {
     int32_t max_proto = 0x7FFFFFFF;
     uint32_t le_max = h_to_le32(static_cast<uint32_t>(max_proto));
     if (!odin_command(0x64, 0x00, &le_max, sizeof(le_max), rsp, USB_TIMEOUT_CONTROL)) return false;
-    if (!odin_fail_check(rsp, "BeginSession", false)) return false;
+
+    if (rsp.size() < 8) return false;
+
+    int32_t id = 0;
+    std::memcpy(&id, rsp.data(), sizeof(id));
+    id = static_cast<int32_t>(le32toh(static_cast<uint32_t>(id)));
+    if (id == BOOTLOADER_FAIL) {
+        log_error("BeginSession failed with BOOTLOADER_FAIL");
+        return false;
+    }
 
     uint32_t ack_raw = 0;
     std::memcpy(&ack_raw, rsp.data() + 4, sizeof(ack_raw));
@@ -450,10 +459,11 @@ auto UsbDevice::odin_dump_pit(std::vector<unsigned char>& pit_out) -> bool {
     for (uint32_t i = 0; i < blocks; ++i) {
         uint32_t le_i = h_to_le32(i);
         if (!odin_command(0x65, 0x02, &le_i, sizeof(le_i), rsp, 5000)) return false;
-        if (!odin_fail_check(rsp, "PitDumpBlock", false)) return false;
+        if (rsp.size() < 8) return false;
 
         size_t off = static_cast<size_t>(i) * block;
         size_t copy = std::min({rsp.size(), pit_out.size() - off, static_cast<size_t>(block)});
+        if (copy == 0) return false;
         std::memcpy(pit_out.data() + off, rsp.data(), copy);
     }
 

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -179,7 +179,7 @@ static auto find_best_interface(libusb_device* dev, const UsbSelectionCriteria& 
             if (bulk_endpoints == 2) score += 10;
 
             if (score > best.score) {
-                best = {score, id->bInterfaceNumber, j, ep_in, ep_out, ep_out_mps, id->bInterfaceClass, id->bNumEndpoints};
+                best = {score, id->bInterfaceNumber, id->bAlternateSetting, ep_in, ep_out, ep_out_mps, id->bInterfaceClass, id->bNumEndpoints};
             }
         }
     }
@@ -318,7 +318,20 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
 
     const int claim_err = libusb_claim_interface(handle, interface_number);
     if (claim_err == 0 && alt_setting >= 0) {
-        libusb_set_interface_alt_setting(handle, interface_number, alt_setting);
+        int alt_err = libusb_set_interface_alt_setting(handle, interface_number, alt_setting);
+        if (alt_err < 0) {
+            last_open_libusb_err = alt_err;
+            last_open_error = UsbOpenError::Other;
+            log_error("Failed to set USB interface alt setting", alt_err);
+            libusb_release_interface(handle, interface_number);
+            if (kernel_driver_detached) {
+                (void) libusb_attach_kernel_driver(handle, interface_number);
+                kernel_driver_detached = false;
+            }
+            libusb_close(handle);
+            handle = nullptr;
+            return false;
+        }
     }
     if (claim_err < 0) {
         last_open_libusb_err = claim_err;


### PR DESCRIPTION
## Summary

Four additional fixes identified in the protocol analysis review, building on the changes merged in #119.

## Changes

### 1. BeginSession: extract capability flags before response validation
- Move `ack_raw` extraction and `odin_supports_compressed` detection before
  `odin_fail_check` so the compressed-download MSB in ack is not misinterpreted
  as a negative error code
- Validate the response `id` field manually for `BOOTLOADER_FAIL` instead of
  calling the generic check (which clamps on `code < 0`)

### 2. PIT dump: stop misinterpreting payload as status
- Remove `odin_fail_check` from the 0x65/0x02 block-response loop
- The response to this command is raw PIT payload, not a protocol status header;
  validate `rsp.size() >= 8` and copy data directly

### 3. send_control: no duplicate session closure
- Remove the redundant `odin_end_session()` call from the REBOOT path
  (`src/odin4.cpp` already closes the session)
- Return `false` for the unsupported REDOWNLOAD control so callers see a failure

### 4. alt_setting: use descriptor value and check return
- Store `id->bAlternateSetting` (not the array index `j`) so non-contiguous
  alternate numbers are preserved
- Check the return value of `libusb_set_interface_alt_setting` and fail
  `open_device` on error

## Testing
- All 32 existing tests pass
- Clean build with GCC/Clang (C++23)