### PR TITLE
fix(usb): log the failing step in odin_handshake() for easier diagnosis

### DIFF
--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -254,13 +254,29 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
 
 auto UsbDevice::odin_handshake() -> bool {
     const char preamble[4] = {'O', 'D', 'I', 'N'};
-    if (!bulk_write_all(preamble, sizeof(preamble), USB_TIMEOUT_CONTROL)) return false;
+    log_verbose("Handshake: sending ODIN preamble");
+    if (!bulk_write_all(preamble, sizeof(preamble), USB_TIMEOUT_CONTROL)) {
+        log_error("Handshake failed: could not send ODIN preamble on bulk OUT");
+        return false;
+    }
 
     unsigned char reply[512] = {0};
     int actual = 0;
-    if (!bulk_read_once(reply, sizeof(reply), &actual, USB_TIMEOUT_CONTROL)) return false;
-    if (actual < 4) return false;
-    if (reply[0] != 'L' || reply[1] != 'O' || reply[2] != 'K' || reply[3] != 'E') return false;
+    log_verbose("Handshake: waiting for LOKE reply");
+    if (!bulk_read_once(reply, sizeof(reply), &actual, USB_TIMEOUT_CONTROL)) {
+        log_error("Handshake failed: no LOKE reply on bulk IN");
+        return false;
+    }
+    if (actual < 4) {
+        log_error(std::format("Handshake failed: short reply ({} bytes, expected at least 4)", actual));
+        return false;
+    }
+    if (reply[0] != 'L' || reply[1] != 'O' || reply[2] != 'K' || reply[3] != 'E') {
+        log_error(std::format(
+            "Handshake failed: unexpected reply magic 0x{:02X}{:02X}{:02X}{:02X}, expected 'LOKE'",
+            reply[0], reply[1], reply[2], reply[3]));
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
hey,

was poking at `odin_handshake` the other day trying to figure out why a board was timing out, and the only line in the log was the generic `USB handshake failed.` that `src/odin4.cpp:166` prints. the function has four ways to fail (ODIN write, LOKE read, short reply, bad-magic reply) and they all just `return false` silently, so you can't tell from the log which one tripped.

quick fix in `src/usb/odin_protocol.cpp` — two `log_verbose` markers around the bulk-OUT and bulk-IN, plus a `log_error` per failure path. the bad-magic one prints the four reply bytes in hex so it's actually triage-able.

zero behaviour change, same returns in the same order, just nicer logs.

side note: `bulk_read_once` has logged libusb error codes since v6.0.1 (`USB bulk read failed (error: {})`, `usb_device.cpp:116`) but `bulk_write_all` doesn't. so the most critical OUT in the whole protocol — the ODIN preamble — is the least observable. this closes that gap at the handshake site without touching the helpers.

quick sample with `--verbose` on a board that times out at the OUT:
```
2026-... [INFO]    Starting handshake
2026-... [VERBOSE] Handshake: sending ODIN preamble
2026-... [ERROR]   Handshake failed: could not send ODIN preamble on bulk OUT
2026-... [ERROR]   USB handshake failed.
```

builds clean with the same cmake invocation as the README (`g++-14` here, GUI/tests off). public API unchanged, no new deps — `<format>` was already in the file.
