### PR TITLE
fix(usb): reset device before handshake on Linux to unblock first bulk-OUT (heimdall parity)

### DIFF
--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -253,6 +253,18 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
 }
 
 auto UsbDevice::odin_handshake() -> bool {
+    // On Linux, some Samsung Download Mode boards (CDC-ACM composite) NAK the first
+    // bulk-OUT transfer on a freshly-claimed interface until the device is reset on
+    // the host side. Heimdall applies the same workaround in InitialiseProtocol
+    // (gated on IsUbuntu); we apply it on Linux because the failure mode is not
+    // distribution-specific. The reset is best-effort: if it fails, the subsequent
+    // bulk_write_all will surface the underlying error.
+#if defined(__linux__)
+    if (handle != nullptr) {
+        log_verbose("Handshake: resetting device before ODIN preamble (Linux libusb workaround)");
+        (void) libusb_reset_device(handle);
+    }
+#endif
     const char preamble[4] = {'O', 'D', 'I', 'N'};
     if (!bulk_write_all(preamble, sizeof(preamble), USB_TIMEOUT_CONTROL)) return false;
 


### PR DESCRIPTION
tl;dr: porting heimdall's `IsUbuntu` workaround to odin4, but ungated (`__linux__`) because the failure isn't ubuntu-specific.

hit a wall trying to flash a Z Flip 4 (SM-F721B / b4q / SM8475) on linux: `open_device()` succeeds, then `odin_handshake()` enters and the ODIN write on bulk-OUT 0x01 just sits there for 10 s until `USB_TIMEOUT_CONTROL` fires. heimdall on the same board + same cable + same host completes the handshake just fine, so the device wasn't borked — odin4 just couldn't get the first byte across.

dug into heimdall's source and they've had this exact workaround for years in `source/BridgeManager.cpp` (`InitialiseProtocol`), gated on `IsUbuntu()`:

```cpp
#ifdef OS_LINUX
    if (IsUbuntu())
    {
        Interface::Print("Resetting device...\n");
        if (libusb_reset_device(deviceHandle))
        {
            Interface::PrintError("Failed to reset device!\n");
        }
    }
#endif
```

i'm not on ubuntu and a few threads on the heimdall side say the same thing happens on debian/arch/fedora — looks more like a generic linux+samsung-CDC-ACM quirk than an ubuntu-specific one. so this PR widens the gate to `__linux__`, in the same spirit as #138's platform conditionals.

just a single `libusb_reset_device(handle)` call before the ODIN write, return value swallowed on purpose — if the reset itself errors out, `bulk_write_all()` will surface the real USB error via its log path anyway. on boards that didn't need it, the reset is effectively a no-op on a quiescent endpoint.

### what i actually measured

A/B on the same SM-F721B, same v7.3.0 binary (built with some `log_verbose` probes around the handshake), same USB session, same combo — only difference = whether the reset runs:

| | outcome |
|---|---|
| **no reset** | handshake fails after 5×~10 s timeouts. bulk-OUT `0x01` write: `rc=-7 LIBUSB_ERROR_TIMEOUT actual=0 offset=0/4`, `dmesg` silent. |
| **reset before ODIN** | `Handshake successful.` in ~170 ms. session continues: `Received PIT entries: 111`, `BULK_IN_RES rc=0`, `FAIL_CHECK code=0` across EndPitDump / SetTotalBytes / EndSession. |

USB descriptor on this board: IF0 = CDC-control (no bulk eps), IF1 = CDC-data (bulk `0x01` / `0x81`) — odin4 already picks IF1 correctly via `find_best_interface`. the reset is the variable that unblocks the first OUT, exactly the symptom heimdall's workaround addresses.

ran with `--check-only` so this was a handshake-only test — whether the subsequent flushing behaves the same is a separate question, out of scope here.

### what this PR doesn't claim

- not saying every linux + samsung download combo needed this before; just that adding it matches heimdall's known-good path and unblocks at least one board that reliably timed out on v7.3.0.
- nothing about flashing reliability past the handshake — different thread.

would love a sanity check from someone on a non-ubuntu distro with a board that previously hung at the handshake, to confirm `__linux__` is the right scope. companion observability PR #145 makes that kind of report much easier to triage.

builds clean with cmake (`g++-14`, GUI/tests off). linux-only path, no change on win/mac, no new deps — `libusb_reset_device` is already used by the project's cousins (heimdall, brokkr).
