### PR TITLE
usb: fix Download Mode support for newer CDC ACM bootloaders (SM-A055M)

### DIFF
--- a/docs/THOR_PROTOCOL.md
+++ b/docs/THOR_PROTOCOL.md
@@ -23,7 +23,7 @@ The Download Mode function is a composite CDC ACM modem: interface 0 is the Comm
 
 Newer bootloaders — observed and verified on the MediaTek-based SM-A055M (PID `0x685D`) — additionally answer the `ODIN`/`LOKE` handshake **exactly once per USB connection**. Any earlier traffic on the data pipe (a previous failed or completed session, or a host service such as ModemManager probing the `ttyACM` port) leaves the bootloader silently ignoring bulk transfers: `ODIN` writes are ACKed at the USB layer but no `LOKE` ever arrives. A USB port reset restores the handshake state. odin4 therefore attempts the handshake once with a short timeout and, if the device stays silent, resets the port and retries. The reset is not performed unconditionally because a small number of older devices are known to stop handshaking after a reset (see Heimdall PR #478).
 
-These bootloaders also answer `RQT_CLOSE` commands with `id = -1` and `ack = 0` on success; only a negative `ack` indicates a real failure for close commands.
+These bootloaders also answer `RQT_CLOSE` commands (`EndSession`, `Reboot`, `RebootToOdin`) with `id = -1` and `ack = 0` on **success**; odin4 treats that specific combination as success and evaluates every other response with normal validation, where a negative `ack` remains a real failure.
 
 ## 3. Packet Structures
 

--- a/docs/THOR_PROTOCOL.md
+++ b/docs/THOR_PROTOCOL.md
@@ -17,6 +17,14 @@ Before any data transfer, the host performs a handshake to confirm the device bo
 *   **Host to Device**: Sends the ASCII string `ODIN` (4 bytes).
 *   **Device to Host**: Responds with the ASCII string `LOKE` (4 bytes).
 
+#### 2.1.1. CDC ACM Port Open and One-Shot Handshake (newer devices)
+
+The Download Mode function is a composite CDC ACM modem: interface 0 is the Communications class (`0x02`) control interface and interface 1 is the CDC Data (`0x0A`) interface carrying the bulk endpoints. Windows hosts talk to it through a CDC serial driver, which "opens the port" (SET_LINE_CODING + SET_CONTROL_LINE_STATE with DTR/RTS) before any data flows. odin4 replicates this on open so it presents the same host behavior a working Windows Odin session does.
+
+Newer bootloaders — observed and verified on the MediaTek-based SM-A055M (PID `0x685D`) — additionally answer the `ODIN`/`LOKE` handshake **exactly once per USB connection**. Any earlier traffic on the data pipe (a previous failed or completed session, or a host service such as ModemManager probing the `ttyACM` port) leaves the bootloader silently ignoring bulk transfers: `ODIN` writes are ACKed at the USB layer but no `LOKE` ever arrives. A USB port reset restores the handshake state. odin4 therefore attempts the handshake once with a short timeout and, if the device stays silent, resets the port and retries. The reset is not performed unconditionally because a small number of older devices are known to stop handshaking after a reset (see Heimdall PR #478).
+
+These bootloaders also answer `RQT_CLOSE` commands with `id = -1` and `ack = 0` on success; only a negative `ack` indicates a real failure for close commands.
+
 ## 3. Packet Structures
 
 After the handshake, all command communication uses two fixed-size structures: the request box and the response box. Raw data transfers bypass this structure and use the negotiated packet size directly.

--- a/src/protocol/thor_protocol.h
+++ b/src/protocol/thor_protocol.h
@@ -131,6 +131,18 @@ constexpr std::size_t kLokeResponseSize     = 4;
 // PIT download chunk size (used for legacy protocol)
 constexpr std::size_t kPitChunkSize = 500;
 
+// CDC ACM class requests (USB CDC PSTN 1.2, section 6.3). Newer Download Mode
+// devices (e.g. SM-A055M, PID 0x685D) enumerate as a CDC ACM modem and their
+// bootloader ignores bulk traffic until the host "opens the port" by asserting
+// DTR via SET_CONTROL_LINE_STATE, exactly like a serial terminal would.
+constexpr uint8_t kCdcReqSetLineCoding       = 0x20;
+constexpr uint8_t kCdcReqSetControlLineState = 0x22;
+constexpr uint16_t kCdcControlLineDtr = 0x0001;
+constexpr uint16_t kCdcControlLineRts = 0x0002;
+
+// 115200 baud, 1 stop bit, no parity, 8 data bits (dwDTERate LE + bCharFormat + bParityType + bDataBits)
+constexpr unsigned char kCdcDefaultLineCoding[7] = {0x00, 0xC2, 0x01, 0x00, 0x00, 0x00, 0x08};
+
 // Control types for send_control
 enum OdinControlType : uint32_t {
     ODIN_CONTROL_REBOOT = 0x0001,

--- a/src/protocol/thor_protocol.h
+++ b/src/protocol/thor_protocol.h
@@ -135,7 +135,7 @@ constexpr std::size_t kPitChunkSize = 500;
 // devices (e.g. SM-A055M, PID 0x685D) enumerate as a CDC ACM modem and their
 // bootloader ignores bulk traffic until the host "opens the port" by asserting
 // DTR via SET_CONTROL_LINE_STATE, exactly like a serial terminal would.
-constexpr uint8_t kCdcReqSetLineCoding       = 0x20;
+constexpr uint8_t kCdcReqSetLineCoding = 0x20;
 constexpr uint8_t kCdcReqSetControlLineState = 0x22;
 constexpr uint16_t kCdcControlLineDtr = 0x0001;
 constexpr uint16_t kCdcControlLineRts = 0x0002;

--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -742,7 +742,6 @@ auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, cons
     uint64_t total_sent = 0;
     std::vector<unsigned char> part(static_cast<size_t>(odin_flash_packet_size), 0);
 
-    uint32_t expected_index = 0;
     for (uint32_t i = 0; i < sequences; ++i) {
         const bool last = (i + 1 == sequences);
         uint32_t real_size = last ? last_sequence : static_cast<uint32_t>(sequence_bytes);
@@ -758,6 +757,9 @@ auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, cons
 
         if (!odin_request_sequence_flash(aligned_size)) return false;
 
+        // The device acks each file part with its index within the current
+        // sequence, restarting at 0 after every RequestSequenceFlash.
+        uint32_t expected_index = 0;
         const uint32_t parts = aligned_size / static_cast<uint32_t>(odin_flash_packet_size);
         for (uint32_t j = 0; j < parts; ++j) {
             std::fill(part.begin(), part.end(), 0);
@@ -933,13 +935,14 @@ auto UsbDevice::flash_partition_stream_compressed(std::istream& stream, uint64_t
     std::vector<unsigned char> buf(static_cast<size_t>(odin_flash_packet_size), 0);
 
     uint64_t prev_decomp = 0;
-    uint32_t expected_index = 0;
     for (uint32_t i = 0; i < sequences; ++i) {
         const bool last = (i + 1 == sequences);
         const uint32_t seq_size = last ? static_cast<uint32_t>(last_seq64) : static_cast<uint32_t>(sequence_bytes);
 
         if (!odin_request_sequence_flash_compressed(seq_size)) return false;
 
+        // Per-sequence part index; the device restarts its counter each sequence.
+        uint32_t expected_index = 0;
         uint64_t remaining = seq_size;
         while (remaining > 0) {
             const size_t to_read = static_cast<size_t>(std::min<uint64_t>(remaining, buf.size()));

--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -252,7 +252,7 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
     return true;
 }
 
-auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
+auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> HandshakeResult {
     const unsigned char preamble[4] = {'O', 'D', 'I', 'N'};
 
     int actual = 0;
@@ -260,7 +260,7 @@ auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
                                    &actual, 2000);
     if (err != 0 || actual != sizeof(preamble)) {
         log_verbose(std::format("Handshake write failed (error: {}, sent: {})", err, actual));
-        return false;
+        return HandshakeResult::Failure;
     }
 
     unsigned char reply[512] = {0};
@@ -268,21 +268,30 @@ auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
     err = libusb_bulk_transfer(handle, endpoint_in, reply, sizeof(reply), &actual, read_timeout_ms);
     if (err != 0) {
         log_verbose(std::format("Handshake read failed (error: {})", err));
-        return false;
+        // Only a timeout with zero bytes transferred is the "bootloader never
+        // answered" case a reset can fix; a timeout that delivered a partial
+        // reply, or any other libusb error, is a different failure and
+        // resetting the port would not help (and could make things worse).
+        if (err == LIBUSB_ERROR_TIMEOUT && actual == 0)
+            return HandshakeResult::SilentTimeout;
+        return HandshakeResult::Failure;
     }
 
     if (actual < 4)
-        return false;
+        return HandshakeResult::Failure;
 
     if (reply[0] != 'L' || reply[1] != 'O' || reply[2] != 'K' || reply[3] != 'E')
-        return false;
+        return HandshakeResult::Failure;
 
-    return true;
+    return HandshakeResult::Success;
 }
 
 auto UsbDevice::odin_handshake() -> bool {
-    if (odin_handshake_attempt(3000))
+    const HandshakeResult first = odin_handshake_attempt(3000);
+    if (first == HandshakeResult::Success)
         return true;
+    if (first != HandshakeResult::SilentTimeout)
+        return false;
 
     // Newer Download Mode bootloaders (observed on the MTK-based SM-A055M, PID 0x685D)
     // answer the ODIN/LOKE handshake exactly once per USB connection. Any prior traffic
@@ -295,7 +304,7 @@ auto UsbDevice::odin_handshake() -> bool {
     if (!reset_and_reinit())
         return false;
 
-    return odin_handshake_attempt(5000);
+    return odin_handshake_attempt(5000) == HandshakeResult::Success;
 }
 
 auto UsbDevice::odin_command(uint32_t cmd, uint32_t subcmd, const void* payload, size_t payload_size,

--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -256,8 +256,8 @@ auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
     const unsigned char preamble[4] = {'O', 'D', 'I', 'N'};
 
     int actual = 0;
-    int err = libusb_bulk_transfer(handle, endpoint_out, const_cast<unsigned char*>(preamble),
-                                   sizeof(preamble), &actual, 2000);
+    int err = libusb_bulk_transfer(handle, endpoint_out, const_cast<unsigned char*>(preamble), sizeof(preamble),
+                                   &actual, 2000);
     if (err != 0 || actual != sizeof(preamble)) {
         log_verbose(std::format("Handshake write failed (error: {}, sent: {})", err, actual));
         return false;
@@ -274,10 +274,7 @@ auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
     if (actual < 4)
         return false;
 
-    if (reply[0] != 'L' ||
-        reply[1] != 'O' ||
-        reply[2] != 'K' ||
-        reply[3] != 'E')
+    if (reply[0] != 'L' || reply[1] != 'O' || reply[2] != 'K' || reply[3] != 'E')
         return false;
 
     return true;

--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -255,17 +255,17 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
 auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> HandshakeResult {
     const unsigned char preamble[4] = {'O', 'D', 'I', 'N'};
 
-    int actual = 0;
-    int err = libusb_bulk_transfer(handle, endpoint_out, const_cast<unsigned char*>(preamble), sizeof(preamble),
-                                   &actual, 2000);
-    if (err != 0 || actual != sizeof(preamble)) {
-        log_verbose(std::format("Handshake write failed (error: {}, sent: {})", err, actual));
+    // Route through bulk_write_all() for uniform partial-write/retry behavior.
+    if (!bulk_write_all(preamble, sizeof(preamble), 2000)) {
+        log_verbose("Handshake write failed");
         return HandshakeResult::Failure;
     }
 
+    // The reply path uses raw libusb since only actual == 0 matters for the
+    // timeout classification (silent vs partial).
     unsigned char reply[512] = {0};
-    actual = 0;
-    err = libusb_bulk_transfer(handle, endpoint_in, reply, sizeof(reply), &actual, read_timeout_ms);
+    int actual = 0;
+    int err = libusb_bulk_transfer(handle, endpoint_in, reply, sizeof(reply), &actual, read_timeout_ms);
     if (err != 0) {
         log_verbose(std::format("Handshake read failed (error: {})", err));
         // Only a timeout with zero bytes transferred is the "bootloader never

--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -252,16 +252,53 @@ auto UsbDevice::send_control(uint32_t control_type) -> bool {
     return true;
 }
 
-auto UsbDevice::odin_handshake() -> bool {
-    const char preamble[4] = {'O', 'D', 'I', 'N'};
-    if (!bulk_write_all(preamble, sizeof(preamble), USB_TIMEOUT_CONTROL)) return false;
+auto UsbDevice::odin_handshake_attempt(int read_timeout_ms) -> bool {
+    const unsigned char preamble[4] = {'O', 'D', 'I', 'N'};
+
+    int actual = 0;
+    int err = libusb_bulk_transfer(handle, endpoint_out, const_cast<unsigned char*>(preamble),
+                                   sizeof(preamble), &actual, 2000);
+    if (err != 0 || actual != sizeof(preamble)) {
+        log_verbose(std::format("Handshake write failed (error: {}, sent: {})", err, actual));
+        return false;
+    }
 
     unsigned char reply[512] = {0};
-    int actual = 0;
-    if (!bulk_read_once(reply, sizeof(reply), &actual, USB_TIMEOUT_CONTROL)) return false;
-    if (actual < 4) return false;
-    if (reply[0] != 'L' || reply[1] != 'O' || reply[2] != 'K' || reply[3] != 'E') return false;
+    actual = 0;
+    err = libusb_bulk_transfer(handle, endpoint_in, reply, sizeof(reply), &actual, read_timeout_ms);
+    if (err != 0) {
+        log_verbose(std::format("Handshake read failed (error: {})", err));
+        return false;
+    }
+
+    if (actual < 4)
+        return false;
+
+    if (reply[0] != 'L' ||
+        reply[1] != 'O' ||
+        reply[2] != 'K' ||
+        reply[3] != 'E')
+        return false;
+
     return true;
+}
+
+auto UsbDevice::odin_handshake() -> bool {
+    if (odin_handshake_attempt(3000))
+        return true;
+
+    // Newer Download Mode bootloaders (observed on the MTK-based SM-A055M, PID 0x685D)
+    // answer the ODIN/LOKE handshake exactly once per USB connection. Any prior traffic
+    // on the CDC data pipe — an earlier failed or completed run, or a host service
+    // probing the modem port — leaves the bootloader silently ignoring bulk transfers.
+    // A USB port reset restores the handshake state, so reset and try again before
+    // giving up. The reset is deliberately not done up front: a small number of older
+    // devices are known to stop handshaking after a reset (see Heimdall PR #478).
+    log_info("No handshake response; resetting USB device and retrying");
+    if (!reset_and_reinit())
+        return false;
+
+    return odin_handshake_attempt(5000);
 }
 
 auto UsbDevice::odin_command(uint32_t cmd, uint32_t subcmd, const void* payload, size_t payload_size,
@@ -412,22 +449,41 @@ auto UsbDevice::odin_begin_session() -> bool {
     return true;
 }
 
+// Some newer bootloaders (observed on the MTK-based SM-A055M) answer RQT_CLOSE
+// commands with id = -1 (BOOTLOADER_FAIL) but ack = 0; the zero ack means the close
+// succeeded, so only a negative ack is treated as a real failure for these commands.
+auto UsbDevice::odin_close_fail_check(const std::vector<unsigned char>& rsp, const std::string& context) -> bool {
+    if (rsp.size() >= 8) {
+        int32_t id = 0;
+        int32_t code = 0;
+        std::memcpy(&id, rsp.data(), sizeof(id));
+        std::memcpy(&code, rsp.data() + 4, sizeof(code));
+        id = static_cast<int32_t>(le32toh(static_cast<uint32_t>(id)));
+        code = static_cast<int32_t>(le32toh(static_cast<uint32_t>(code)));
+        if (id == BOOTLOADER_FAIL && code == 0) {
+            log_verbose(context + ": bootloader answered with id=-1, ack=0; treating as success");
+            return true;
+        }
+    }
+    return odin_fail_check(rsp, context, false);
+}
+
 auto UsbDevice::odin_end_session() -> bool {
     std::vector<unsigned char> rsp;
     if (!odin_command(0x67, 0x00, nullptr, 0, rsp, USB_TIMEOUT_CONTROL)) return false;
-    return odin_fail_check(rsp, "EndSession", false);
+    return odin_close_fail_check(rsp, "EndSession");
 }
 
 auto UsbDevice::odin_reboot() -> bool {
     std::vector<unsigned char> rsp;
     if (!odin_command(0x67, 0x01, nullptr, 0, rsp, USB_TIMEOUT_CONTROL)) return false;
-    return odin_fail_check(rsp, "Reboot", false);
+    return odin_close_fail_check(rsp, "Reboot");
 }
 
 auto UsbDevice::odin_reboot_to_odin() -> bool {
     std::vector<unsigned char> rsp;
     if (!odin_command(0x67, 0x02, nullptr, 0, rsp, USB_TIMEOUT_CONTROL)) return false;
-    return odin_fail_check(rsp, "RebootToOdin", false);
+    return odin_close_fail_check(rsp, "RebootToOdin");
 }
 
 auto UsbDevice::odin_request_device_type(std::string& out_type) -> bool {

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -387,6 +387,23 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
         return false;
     }
 
+    if (alt_setting > 0) {
+        const int alt_err = libusb_set_interface_alt_setting(handle, interface_number, alt_setting);
+        if (alt_err < 0) {
+            last_open_libusb_err = alt_err;
+            last_open_error = UsbOpenError::Other;
+            log_error("Failed to activate alternate setting", alt_err);
+            libusb_release_interface(handle, interface_number);
+            if (kernel_driver_detached) {
+                (void) libusb_attach_kernel_driver(handle, interface_number);
+                kernel_driver_detached = false;
+            }
+            libusb_close(handle);
+            handle = nullptr;
+            return false;
+        }
+    }
+
     initialize_cdc_acm();
 
     std::ostringstream oss;
@@ -537,6 +554,14 @@ auto UsbDevice::reset_and_reinit() -> bool {
     if (claim_err < 0) {
         log_warn(std::format("Failed to re-claim USB data interface after reset (error: {})", claim_err));
         return false;
+    }
+
+    if (alt_setting > 0) {
+        const int alt_err = libusb_set_interface_alt_setting(handle, interface_number, alt_setting);
+        if (alt_err < 0) {
+            log_warn(std::format("Failed to restore alternate setting after reset (error: {})", alt_err));
+            return false;
+        }
     }
 
     // The CDC claim state may not have survived the reset either; make

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -548,12 +548,29 @@ auto UsbDevice::reset_and_reinit() -> bool {
     // it. The CDC communications interface is best-effort: initialize_cdc_acm()
     // already falls back to device-recipient control transfers if it cannot be
     // claimed, so a failure there is not fatal to the retry.
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
+    //
+    // On Linux, libusb_reset_device()'s internal reconnect can re-claim previously
+    // claimed interfaces automatically, so our explicit claim may return
+    // LIBUSB_ERROR_INVALID_PARAM (already claimed by us) or LIBUSB_ERROR_BUSY
+    // (kernel re-bound cdc_acm). In those cases the interface is usable; only
+    // other errors are fatal.
     const int claim_err = libusb_claim_interface(handle, interface_number);
-    if (claim_err < 0) {
+    if (claim_err < 0 && claim_err != LIBUSB_ERROR_INVALID_PARAM && claim_err != LIBUSB_ERROR_BUSY) {
         log_warn(std::format("Failed to re-claim USB data interface after reset (error: {})", claim_err));
         return false;
+    }
+    if (claim_err == LIBUSB_ERROR_BUSY) {
+        // Kernel re-bound; try detaching it
+        if (libusb_detach_kernel_driver(handle, interface_number) == 0) {
+            kernel_driver_detached = true;
+            if (libusb_claim_interface(handle, interface_number) < 0) {
+                log_warn("Failed to claim interface after detaching kernel driver post-reset");
+                return false;
+            }
+        } else {
+            log_warn("Interface busy after reset and kernel driver detach failed");
+            return false;
+        }
     }
 
     if (alt_setting > 0) {

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -189,25 +189,53 @@ static auto find_best_interface(libusb_device* dev, const UsbSelectionCriteria& 
     return best;
 }
 
-static auto find_cdc_comm_interface(libusb_device* dev) -> int {
+// Resolves the CDC Communications interface paired with `data_interface_number`
+// by parsing the CDC Union Functional Descriptor (CDC 1.2 section 5.2.3.8),
+// a class-specific descriptor embedded in the Communications interface's
+// "extra" descriptor bytes: bLength, bDescriptorType (0x24, CS_INTERFACE),
+// bDescriptorSubtype (0x06, Union), bMasterInterface, bSlaveInterface0, ...
+// This correctly pairs control/data interfaces on composite devices that
+// expose more than one CDC function. Devices without a well-formed union
+// descriptor fall back to the first Communications-class interface found.
+static auto find_cdc_comm_interface(libusb_device* dev, int data_interface_number) -> int {
     libusb_config_descriptor* config = nullptr;
     if (libusb_get_active_config_descriptor(dev, &config) != 0 || (config == nullptr))
         return -1;
 
-    int comm_interface = -1;
-    for (int i = 0; i < config->bNumInterfaces && comm_interface < 0; ++i) {
+    int fallback_comm_interface = -1;
+
+    for (int i = 0; i < config->bNumInterfaces; ++i) {
         const libusb_interface* inter = &config->interface[i];
         for (int j = 0; j < inter->num_altsetting; ++j) {
             const libusb_interface_descriptor* id = &inter->altsetting[j];
-            if (id->bInterfaceClass == LIBUSB_CLASS_COMM) {
-                comm_interface = id->bInterfaceNumber;
-                break;
+            if (id->bInterfaceClass != LIBUSB_CLASS_COMM) continue;
+            if (fallback_comm_interface < 0) fallback_comm_interface = id->bInterfaceNumber;
+
+            const unsigned char* p = id->extra;
+            int remaining = id->extra_length;
+            while (remaining >= 2) {
+                const auto desc_len = static_cast<int>(p[0]);
+                const auto desc_type = p[1];
+                if (desc_len < 2 || desc_len > remaining) break;
+
+                if (desc_type == 0x24 && desc_len >= 5 && p[2] == 0x06) {
+                    const uint8_t master = p[3];
+                    for (int s = 4; s < desc_len; ++s) {
+                        if (p[s] == data_interface_number && master == id->bInterfaceNumber) {
+                            libusb_free_config_descriptor(config);
+                            return id->bInterfaceNumber;
+                        }
+                    }
+                }
+
+                p += desc_len;
+                remaining -= desc_len;
             }
         }
     }
 
     libusb_free_config_descriptor(config);
-    return comm_interface;
+    return fallback_comm_interface;
 }
 
 auto UsbDevice::open_device(const std::string& specific_path) -> bool {
@@ -303,7 +331,7 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     interface_number = chosen_if.interface_number;
     alt_setting = chosen_if.alt_setting;
     kernel_driver_detached = false;
-    cdc_comm_interface = find_cdc_comm_interface(target);
+    cdc_comm_interface = find_cdc_comm_interface(target, chosen_if.interface_number);
     cdc_comm_claimed = false;
     cdc_comm_driver_detached = false;
 
@@ -497,10 +525,23 @@ auto UsbDevice::reset_and_reinit() -> bool {
         return false;
     }
 
-    // Interfaces claimed through this handle survive a successful reset, but the
-    // device-side CDC state (line coding, DTR) does not — re-open the port.
+    // libusb only says the system "attempts" to restore the previous configuration
+    // and claimed interfaces after a reset — it is not guaranteed, so re-claim the
+    // data interface explicitly and fail rather than proceed without ownership of
+    // it. The CDC communications interface is best-effort: initialize_cdc_acm()
+    // already falls back to device-recipient control transfers if it cannot be
+    // claimed, so a failure there is not fatal to the retry.
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    (void) libusb_claim_interface(handle, interface_number);
+
+    const int claim_err = libusb_claim_interface(handle, interface_number);
+    if (claim_err < 0) {
+        log_warn(std::format("Failed to re-claim USB data interface after reset (error: {})", claim_err));
+        return false;
+    }
+
+    // The CDC claim state may not have survived the reset either; make
+    // initialize_cdc_acm() re-evaluate and re-claim it rather than assume.
+    cdc_comm_claimed = false;
     initialize_cdc_acm();
     return true;
 }

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -191,7 +191,8 @@ static auto find_best_interface(libusb_device* dev, const UsbSelectionCriteria& 
 
 static auto find_cdc_comm_interface(libusb_device* dev) -> int {
     libusb_config_descriptor* config = nullptr;
-    if (libusb_get_active_config_descriptor(dev, &config) != 0 || (config == nullptr)) return -1;
+    if (libusb_get_active_config_descriptor(dev, &config) != 0 || (config == nullptr))
+        return -1;
 
     int comm_interface = -1;
     for (int i = 0; i < config->bNumInterfaces && comm_interface < 0; ++i) {
@@ -370,7 +371,8 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
 }
 
 void UsbDevice::release_cdc_comm_interface() {
-    if (handle == nullptr) return;
+    if (handle == nullptr)
+        return;
     if (cdc_comm_claimed) {
         libusb_release_interface(handle, cdc_comm_interface);
         cdc_comm_claimed = false;
@@ -386,7 +388,8 @@ void UsbDevice::initialize_cdc_acm() {
     // serial host (or Windows Odin's CDC driver) would: set a line coding and raise
     // DTR/RTS on the communications interface before talking on the data interface.
     // Idempotent: safe to call again after a USB reset (claims are kept across it).
-    if (cdc_comm_interface < 0) return;
+    if (cdc_comm_interface < 0)
+        return;
 
     if (cdc_comm_interface != interface_number && !cdc_comm_claimed) {
         const int drv = libusb_kernel_driver_active(handle, cdc_comm_interface);
@@ -408,8 +411,8 @@ void UsbDevice::initialize_cdc_acm() {
 
     unsigned char line_coding[sizeof(kCdcDefaultLineCoding)];
     std::memcpy(line_coding, kCdcDefaultLineCoding, sizeof(line_coding));
-    const int lc_err = libusb_control_transfer(handle, bm_request_type, kCdcReqSetLineCoding, 0, w_index,
-                                               line_coding, sizeof(line_coding), 1000);
+    const int lc_err = libusb_control_transfer(handle, bm_request_type, kCdcReqSetLineCoding, 0, w_index, line_coding,
+                                               sizeof(line_coding), 1000);
     if (lc_err < 0)
         log_verbose(std::format("CDC SET_LINE_CODING not accepted (non-fatal, error: {})", lc_err));
 
@@ -481,7 +484,8 @@ auto UsbDevice::receive_packet(void* data, size_t size, int* actual_length, bool
 }
 
 auto UsbDevice::reset_and_reinit() -> bool {
-    if (handle == nullptr) return false;
+    if (handle == nullptr)
+        return false;
 
     const int reset_err = libusb_reset_device(handle);
     if (reset_err == LIBUSB_ERROR_NOT_FOUND || reset_err == LIBUSB_ERROR_NO_DEVICE) {

--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -58,6 +58,7 @@ static auto retry_backoff_ms(int attempt) -> int {
 UsbDevice::~UsbDevice() {
     if (handle != nullptr) {
         libusb_release_interface(handle, interface_number);
+        release_cdc_comm_interface();
         if (kernel_driver_detached) {
             (void) libusb_attach_kernel_driver(handle, interface_number);
             kernel_driver_detached = false;
@@ -188,6 +189,26 @@ static auto find_best_interface(libusb_device* dev, const UsbSelectionCriteria& 
     return best;
 }
 
+static auto find_cdc_comm_interface(libusb_device* dev) -> int {
+    libusb_config_descriptor* config = nullptr;
+    if (libusb_get_active_config_descriptor(dev, &config) != 0 || (config == nullptr)) return -1;
+
+    int comm_interface = -1;
+    for (int i = 0; i < config->bNumInterfaces && comm_interface < 0; ++i) {
+        const libusb_interface* inter = &config->interface[i];
+        for (int j = 0; j < inter->num_altsetting; ++j) {
+            const libusb_interface_descriptor* id = &inter->altsetting[j];
+            if (id->bInterfaceClass == LIBUSB_CLASS_COMM) {
+                comm_interface = id->bInterfaceNumber;
+                break;
+            }
+        }
+    }
+
+    libusb_free_config_descriptor(config);
+    return comm_interface;
+}
+
 auto UsbDevice::open_device(const std::string& specific_path) -> bool {
     UsbSelectionCriteria criteria;
     return open_device(specific_path, criteria);
@@ -199,6 +220,7 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
 
     if (handle != nullptr) {
         libusb_release_interface(handle, interface_number);
+        release_cdc_comm_interface();
         if (kernel_driver_detached) {
             (void) libusb_attach_kernel_driver(handle, interface_number);
             kernel_driver_detached = false;
@@ -280,6 +302,9 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     interface_number = chosen_if.interface_number;
     alt_setting = chosen_if.alt_setting;
     kernel_driver_detached = false;
+    cdc_comm_interface = find_cdc_comm_interface(target);
+    cdc_comm_claimed = false;
+    cdc_comm_driver_detached = false;
 
     const int open_err = libusb_open(target, &handle);
     if (open_err < 0 || (handle == nullptr)) {
@@ -317,22 +342,6 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
     }
 
     const int claim_err = libusb_claim_interface(handle, interface_number);
-    if (claim_err == 0 && alt_setting >= 0) {
-        int alt_err = libusb_set_interface_alt_setting(handle, interface_number, alt_setting);
-        if (alt_err < 0) {
-            last_open_libusb_err = alt_err;
-            last_open_error = UsbOpenError::Other;
-            log_error("Failed to set USB interface alt setting", alt_err);
-            libusb_release_interface(handle, interface_number);
-            if (kernel_driver_detached) {
-                (void) libusb_attach_kernel_driver(handle, interface_number);
-                kernel_driver_detached = false;
-            }
-            libusb_close(handle);
-            handle = nullptr;
-            return false;
-        }
-    }
     if (claim_err < 0) {
         last_open_libusb_err = claim_err;
         if (claim_err == LIBUSB_ERROR_ACCESS)
@@ -349,6 +358,8 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
         return false;
     }
 
+    initialize_cdc_acm();
+
     std::ostringstream oss;
     oss << "USB device opened. Path: " << usb_path_for_device(target) << ", Interface: " << interface_number
         << ", EP IN: 0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(endpoint_in)
@@ -356,6 +367,58 @@ auto UsbDevice::open_device(const std::string& specific_path, const UsbSelection
         << ", OUT wMaxPacketSize: " << endpoint_out_max_packet;
     log_info(oss.str());
     return true;
+}
+
+void UsbDevice::release_cdc_comm_interface() {
+    if (handle == nullptr) return;
+    if (cdc_comm_claimed) {
+        libusb_release_interface(handle, cdc_comm_interface);
+        cdc_comm_claimed = false;
+    }
+    if (cdc_comm_driver_detached) {
+        (void) libusb_attach_kernel_driver(handle, cdc_comm_interface);
+        cdc_comm_driver_detached = false;
+    }
+}
+
+void UsbDevice::initialize_cdc_acm() {
+    // Download Mode devices enumerate as a CDC ACM modem. Open the "port" the way a
+    // serial host (or Windows Odin's CDC driver) would: set a line coding and raise
+    // DTR/RTS on the communications interface before talking on the data interface.
+    // Idempotent: safe to call again after a USB reset (claims are kept across it).
+    if (cdc_comm_interface < 0) return;
+
+    if (cdc_comm_interface != interface_number && !cdc_comm_claimed) {
+        const int drv = libusb_kernel_driver_active(handle, cdc_comm_interface);
+        if (drv == 1 && libusb_detach_kernel_driver(handle, cdc_comm_interface) == 0)
+            cdc_comm_driver_detached = true;
+        if (libusb_claim_interface(handle, cdc_comm_interface) == 0)
+            cdc_comm_claimed = true;
+        else
+            log_verbose("Could not claim CDC communications interface; using device-recipient control transfers");
+    }
+
+    // Linux usbfs rejects interface-recipient control transfers unless that interface is
+    // claimed by us, so fall back to device-recipient (as Heimdall does) when it is not.
+    const bool interface_claimed = cdc_comm_claimed || (cdc_comm_interface == interface_number);
+    const uint8_t bm_request_type = static_cast<uint8_t>(
+        static_cast<unsigned>(LIBUSB_REQUEST_TYPE_CLASS) |
+        static_cast<unsigned>(interface_claimed ? LIBUSB_RECIPIENT_INTERFACE : LIBUSB_RECIPIENT_DEVICE));
+    const auto w_index = static_cast<uint16_t>(cdc_comm_interface);
+
+    unsigned char line_coding[sizeof(kCdcDefaultLineCoding)];
+    std::memcpy(line_coding, kCdcDefaultLineCoding, sizeof(line_coding));
+    const int lc_err = libusb_control_transfer(handle, bm_request_type, kCdcReqSetLineCoding, 0, w_index,
+                                               line_coding, sizeof(line_coding), 1000);
+    if (lc_err < 0)
+        log_verbose(std::format("CDC SET_LINE_CODING not accepted (non-fatal, error: {})", lc_err));
+
+    const int cls_err = libusb_control_transfer(handle, bm_request_type, kCdcReqSetControlLineState,
+                                                kCdcControlLineDtr | kCdcControlLineRts, w_index, nullptr, 0, 1000);
+    if (cls_err < 0)
+        log_warn(std::format("CDC SET_CONTROL_LINE_STATE failed (error: {}); handshake may time out", cls_err));
+    else
+        log_verbose("CDC ACM port opened (DTR|RTS asserted)");
 }
 
 auto UsbDevice::send_packet(const void* data, size_t size, bool is_control) -> bool {
@@ -415,6 +478,27 @@ auto UsbDevice::receive_packet(void* data, size_t size, int* actual_length, bool
     }
 
     return false;
+}
+
+auto UsbDevice::reset_and_reinit() -> bool {
+    if (handle == nullptr) return false;
+
+    const int reset_err = libusb_reset_device(handle);
+    if (reset_err == LIBUSB_ERROR_NOT_FOUND || reset_err == LIBUSB_ERROR_NO_DEVICE) {
+        log_error("USB device re-enumerated after reset; replug the device and run again", reset_err);
+        return false;
+    }
+    if (reset_err < 0) {
+        log_warn(std::format("USB device reset failed (error: {})", reset_err));
+        return false;
+    }
+
+    // Interfaces claimed through this handle survive a successful reset, but the
+    // device-side CDC state (line coding, DTR) does not — re-open the port.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    (void) libusb_claim_interface(handle, interface_number);
+    initialize_cdc_acm();
+    return true;
 }
 
 auto UsbDevice::handshake() -> bool {

--- a/src/usb/usb_device.h
+++ b/src/usb/usb_device.h
@@ -88,7 +88,9 @@ class UsbDevice {
     void initialize_cdc_acm();
     void release_cdc_comm_interface();
     auto reset_and_reinit() -> bool;
-    auto odin_handshake_attempt(int read_timeout_ms) -> bool;
+
+    enum class HandshakeResult { Success, SilentTimeout, Failure };
+    auto odin_handshake_attempt(int read_timeout_ms) -> HandshakeResult;
 
     auto bulk_write_all(const void* data, size_t size, int timeout_ms) -> bool;
     auto bulk_read_once(void* data, size_t size, int* actual_length, int timeout_ms) -> bool;

--- a/src/usb/usb_device.h
+++ b/src/usb/usb_device.h
@@ -39,6 +39,10 @@ class UsbDevice {
     int alt_setting = -1;
     bool kernel_driver_detached = false;
 
+    int cdc_comm_interface = -1;
+    bool cdc_comm_claimed = false;
+    bool cdc_comm_driver_detached = false;
+
     size_t max_chunk_bytes = 1048576;
     uint16_t endpoint_out_max_packet = 512;
 
@@ -79,6 +83,12 @@ class UsbDevice {
                       std::vector<unsigned char>& rsp, int timeout_ms) -> bool;
     static auto odin_fail_check(const std::vector<unsigned char>& rsp, const std::string& context,
                                 bool allow_progress, int32_t expected_id = -1) -> bool;
+    static auto odin_close_fail_check(const std::vector<unsigned char>& rsp, const std::string& context) -> bool;
+
+    void initialize_cdc_acm();
+    void release_cdc_comm_interface();
+    auto reset_and_reinit() -> bool;
+    auto odin_handshake_attempt(int read_timeout_ms) -> bool;
 
     auto bulk_write_all(const void* data, size_t size, int timeout_ms) -> bool;
     auto bulk_read_once(void* data, size_t size, int* actual_length, int timeout_ms) -> bool;

--- a/tests/test_thor_protocol.cpp
+++ b/tests/test_thor_protocol.cpp
@@ -180,7 +180,10 @@ void test_OdinProtocol_CdcAcmRequests() {
     EXPECT_EQ(kCdcDefaultLineCoding[0], 0x00);
     EXPECT_EQ(kCdcDefaultLineCoding[1], 0xC2);
     EXPECT_EQ(kCdcDefaultLineCoding[2], 0x01);
-    EXPECT_EQ(kCdcDefaultLineCoding[6], 0x08);
+    EXPECT_EQ(kCdcDefaultLineCoding[3], 0x00);
+    EXPECT_EQ(kCdcDefaultLineCoding[4], 0x00); // bCharFormat: 1 stop bit
+    EXPECT_EQ(kCdcDefaultLineCoding[5], 0x00); // bParityType: none
+    EXPECT_EQ(kCdcDefaultLineCoding[6], 0x08); // bDataBits: 8
 }
 REGISTER_TEST(OdinProtocol, CdcAcmRequests);
 

--- a/tests/test_thor_protocol.cpp
+++ b/tests/test_thor_protocol.cpp
@@ -169,6 +169,21 @@ void test_OdinProtocol_HandshakeStringSize() {
 }
 REGISTER_TEST(OdinProtocol, HandshakeStringSize);
 
+void test_OdinProtocol_CdcAcmRequests() {
+    // USB CDC PSTN 1.2 section 6.3: these open the ACM "port" so newer CDC-class
+    // Download Mode bootloaders (e.g. SM-A055M) start servicing bulk transfers.
+    EXPECT_EQ(kCdcReqSetLineCoding, 0x20);
+    EXPECT_EQ(kCdcReqSetControlLineState, 0x22);
+    EXPECT_EQ(static_cast<uint16_t>(kCdcControlLineDtr | kCdcControlLineRts), 0x0003);
+    EXPECT_EQ(sizeof(kCdcDefaultLineCoding), 7u);
+    // dwDTERate little-endian 115200, 1 stop bit, no parity, 8 data bits
+    EXPECT_EQ(kCdcDefaultLineCoding[0], 0x00);
+    EXPECT_EQ(kCdcDefaultLineCoding[1], 0xC2);
+    EXPECT_EQ(kCdcDefaultLineCoding[2], 0x01);
+    EXPECT_EQ(kCdcDefaultLineCoding[6], 0x08);
+}
+REGISTER_TEST(OdinProtocol, CdcAcmRequests);
+
 void test_OdinProtocol_MakeRequest_WithInts() {
     std::vector<int32_t> ints = {5, 10};
     OdinRequestBox rq = make_request(OdinCommandType::RQT_INIT, OdinCommandParam::RQT_INIT_PACKETSIZE, ints);


### PR DESCRIPTION
## Summary

Newer Download Mode bootloaders — root-caused and verified on a physical **Galaxy A05 SM-A055M** (MediaTek, `04e8:685d`) — could neither complete the ODIN/LOKE handshake nor flash partitions larger than one transfer sequence. This PR fixes both, making the device fully flashable with odin4 on Linux.

Three protocol-level behaviors were established by probing the physical device (usbmon captures plus dedicated libusb test programs):

1. **The bootloader answers the ODIN/LOKE handshake exactly once per USB connection.** Any prior traffic on the CDC data pipe (an earlier failed/completed run, or a host service probing the `ttyACM` modem port) leaves it silently ignoring bulk transfers: `ODIN` writes are ACKed at the USB layer but no `LOKE` ever arrives, and repeated attempts eventually stop the OUT endpoint ACKing as well. A USB port reset restores the handshake state. Windows Odin never hits this because every plug-in is a fresh enumeration.
2. The device is a composite **CDC ACM modem** (interface 0 = Communications, interface 1 = CDC Data). A Windows host opens the "port" (`SET_LINE_CODING` / `SET_CONTROL_LINE_STATE` with DTR|RTS) before any data flows.
3. **File part acks carry a per-sequence index** (restarting at 0 after every `RequestSequenceFlash`) and **RQT_CLOSE commands answer `id = -1`, `ack = 0` on success.** The global part counter aborted any >30 MiB partition at its second sequence, and treating `id = -1` as `BOOTLOADER_FAIL` failed otherwise-successful sessions.

Changes:
- `odin_handshake()`: try once with a short timeout; on silence, reset the USB port, re-open the CDC port, and retry. The reset is deliberately not unconditional — some older devices are known to stop handshaking after a reset (see Heimdall PR Benjamin-Dobell/Heimdall#478).
- `open_device()`: claim the CDC Communications interface and open the ACM port (line coding 115200 8N1, then DTR|RTS), matching Heimdall, Thor, and the Windows CDC driver; released/reattached on close.
- Flash paths (plain and compressed): reset the expected file part index at each sequence start.
- RQT_CLOSE responses: accept `id = -1` with `ack = 0` as success; only a negative ack is a real failure.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI / Build

## Testing
- [x] Builds successfully (no new warnings; changed lines clang-formatted)
- [x] Manual CLI test (`--check-only` validation runs and full test suite, 38/38 passing, including a new unit test for the CDC ACM constants)
- [x] Device test: full flash of a TWRP tar (80 MiB `recovery.img` across three sequences + `vbmeta` + `vbmeta_system`) to a physical SM-A055M in Download Mode completed successfully and repeatably; PIT retrieval (55 entries), session negotiation (protocol v2), and EndSession all verified.

## Notes

Protocol details are documented in `docs/THOR_PROTOCOL.md` (new section 2.1.1). The handshake retry adds no latency on devices that answer the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved USB CDC ACM setup and interface selection across compatible devices.
  * Added reliable handshake retry behavior when communication is silent.
  * Improved session closing and reboot command compatibility.
  * Reset flash transfer sequencing for more reliable repeated operations.

* **Bug Fixes**
  * Improved USB interface recovery after device resets.
  * Fixed handling of CDC alternate settings and interface claims.
  * Added support for successful bootloader responses with zero acknowledgment.

* **Documentation**
  * Documented CDC initialization and bootloader handshake behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->