### PR TITLE
fix: reset file part index for each sequence

### DIFF
--- a/src/usb/odin_protocol.cpp
+++ b/src/usb/odin_protocol.cpp
@@ -686,7 +686,6 @@ auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, cons
     uint64_t total_sent = 0;
     std::vector<unsigned char> part(static_cast<size_t>(odin_flash_packet_size), 0);
 
-    uint32_t expected_index = 0;
     for (uint32_t i = 0; i < sequences; ++i) {
         const bool last = (i + 1 == sequences);
         uint32_t real_size = last ? last_sequence : static_cast<uint32_t>(sequence_bytes);
@@ -703,6 +702,7 @@ auto UsbDevice::flash_partition_stream(std::istream& stream, uint64_t size, cons
         if (!odin_request_sequence_flash(aligned_size)) return false;
 
         const uint32_t parts = aligned_size / static_cast<uint32_t>(odin_flash_packet_size);
+        uint32_t expected_index = 0;
         for (uint32_t j = 0; j < parts; ++j) {
             std::fill(part.begin(), part.end(), 0);
 
@@ -877,7 +877,6 @@ auto UsbDevice::flash_partition_stream_compressed(std::istream& stream, uint64_t
     std::vector<unsigned char> buf(static_cast<size_t>(odin_flash_packet_size), 0);
 
     uint64_t prev_decomp = 0;
-    uint32_t expected_index = 0;
     for (uint32_t i = 0; i < sequences; ++i) {
         const bool last = (i + 1 == sequences);
         const uint32_t seq_size = last ? static_cast<uint32_t>(last_seq64) : static_cast<uint32_t>(sequence_bytes);
@@ -885,6 +884,7 @@ auto UsbDevice::flash_partition_stream_compressed(std::istream& stream, uint64_t
         if (!odin_request_sequence_flash_compressed(seq_size)) return false;
 
         uint64_t remaining = seq_size;
+        uint32_t expected_index = 0;
         while (remaining > 0) {
             const size_t to_read = static_cast<size_t>(std::min<uint64_t>(remaining, buf.size()));
             stream.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(to_read));


### PR DESCRIPTION
Fixes #187.

Samsung bootloaders number file-part acknowledgements from zero for each transfer sequence. The current implementation keeps one counter across sequences, so the first part of sequence two is rejected as `expected 30 got 0`.

Reset the expected part index at the start of every normal and compressed sequence.

Validation:
- reproduced on SM-A307FN at the first 30-part boundary
- the patched build passed that boundary and completed BOOT
- GCC 14 release build succeeds
- all 37 tests pass
- git diff --check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-part acknowledgment tracking now resets correctly at the start of each flash sequence, improving reliability for both compressed and uncompressed partition transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->