### PR TITLE
fix: skip non-flashable Samsung package metadata

### DIFF
--- a/src/firmware/firmware_package.cpp
+++ b/src/firmware/firmware_package.cpp
@@ -851,6 +851,22 @@ auto process_tar_file(const std::string& tar_path, UsbDevice& usb_device, const 
         const std::string base_name_sanitized = to_lower_copy(sanitize_filename(basename));
         const std::string filename_lower = to_lower_copy(filename);
 
+        // Samsung firmware archives may contain package metadata alongside
+        // partition images. FOTA metadata and a root-level PIT describe the
+        // package/layout; neither is a flashable partition payload unless an
+        // explicit repartition flow is requested (which this tool does not
+        // expose). Keep every other unknown archive entry rejected by default.
+        const bool is_root_pit = filename.find('/') == std::string::npos &&
+                                 ends_with_case_insensitive(filename_lower, ".pit");
+        if (filename_lower == "meta-data/fota.zip" || is_root_pit) {
+            log_verbose("Skipping Samsung package metadata entry: " + filename);
+            ec = skip_entry_data(data_size);
+            if (ec != ExitCode::Success) {
+                return ec;
+            }
+            continue;
+        }
+
         const PitEntry* pit_entry = nullptr;
         std::string partition_name;
 


### PR DESCRIPTION
Samsung stock firmware archives commonly contain package metadata that is not a flashable PIT partition payload:

- `meta-data/fota.zip`
- a root-level `*.pit` layout file

Strict archive validation currently rejects both as unknown partitions, which makes `--check-only` fail on otherwise valid BL/AP/CP/CSC packages. Skip only these narrowly defined metadata entries while continuing to reject every other unknown archive entry unless `--allow-unknown` is explicitly set.

Validated with stock SM-A307FN Android 11 firmware:
- MD5 verification succeeds for BL/AP/CP/CSC
- 37-entry device PIT parsed successfully
- all partition images matched the PIT
- strict `--check-only` completed successfully without `--allow-unknown`
- GCC 14 release build succeeds
- all 37 tests pass
- git diff --check passes